### PR TITLE
fix reverse pre/postscript tags

### DIFF
--- a/app/spiffworkflow/PropertiesPanel/SpiffWorkflowPropertiesProvider.js
+++ b/app/spiffworkflow/PropertiesPanel/SpiffWorkflowPropertiesProvider.js
@@ -54,12 +54,12 @@ function preScriptPostScriptGroup(element, translate, moddle) {
     entries: [
       ...scriptProps(element,
         moddle,
-        SCRIPT_TYPE.post,
+        SCRIPT_TYPE.pre,
         'Pre-Script',
         'Code to execute prior to this task.'),
       ...scriptProps(element,
         moddle,
-        SCRIPT_TYPE.pre,
+        SCRIPT_TYPE.post,
         'Post-Script',
         'code to execute after this task.')
     ]


### PR DESCRIPTION
The pre-script in the UI was getting mapped to the post-script in the XML and vice versa.