### PR TITLE
Chore/bug fixes

### DIFF
--- a/app/spiffworkflow/DataObject/DataObjectHelpers.js
+++ b/app/spiffworkflow/DataObject/DataObjectHelpers.js
@@ -17,3 +17,13 @@ export function findDataObject(process, id) {
     }
   }
 }
+
+export function findDataReferences(process, id) {
+  let refs = [];
+  for (const element of process.children) {
+    if (element.type === 'bpmn:DataObjectReference') {
+      refs.push(element);
+    }
+  }
+  return refs;
+}

--- a/app/spiffworkflow/PropertiesPanel/SpiffWorkflowPropertiesProvider.js
+++ b/app/spiffworkflow/PropertiesPanel/SpiffWorkflowPropertiesProvider.js
@@ -3,7 +3,7 @@ import { is, isAny } from 'bpmn-js/lib/util/ModelUtil';
 import { DataObjectSelect } from './parts/DataObjectSelect';
 import { ListGroup, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
 import { DataObjectArray } from './parts/DataObjectArray';
-import {SpiffExtensionTextInput} from './parts/SpiffExtensionTextInput';
+import { SpiffExtensionTextInput } from './parts/SpiffExtensionTextInput';
 const LOW_PRIORITY = 500;
 
 export default function SpiffWorkflowPropertiesProvider(propertiesPanel, translate, moddle, commandStack, elementRegistry) {
@@ -17,7 +17,7 @@ export default function SpiffWorkflowPropertiesProvider(propertiesPanel, transla
       if (is(element, 'bpmn:DataObjectReference')) {
         groups.push(createDataObjectSelector(element, translate, moddle, commandStack));
       }
-      if (is(element, 'bpmn:Process')) {
+      if (isAny(element, [ 'bpmn:Process', 'bpmn:SubProcess' ])) {
         groups.push(createDataObjectEditor(element, translate, moddle, commandStack, elementRegistry));
       }
       if (is(element, 'bpmn:UserTask')) {

--- a/app/spiffworkflow/PropertiesPanel/parts/DataObjectArray.js
+++ b/app/spiffworkflow/PropertiesPanel/parts/DataObjectArray.js
@@ -1,7 +1,7 @@
 import { useService } from 'bpmn-js-properties-panel';
 import { isTextFieldEntryEdited, TextFieldEntry } from '@bpmn-io/properties-panel';
 import { without } from 'min-dash';
-import { findDataObjects } from '../../DataObject/DataObjectHelpers';
+import {findDataObjects, findDataReferences} from '../../DataObject/DataObjectHelpers';
 
 /**
  * Provides a list of data objects, and allows you to add / remove data objects, and change their ids.
@@ -104,7 +104,7 @@ function DataObjectTextField(props) {
   const debounce = useService('debounceInput');
 
   const setValue = (value) => {
-    return commandStack.execute(
+    commandStack.execute(
       'element.updateModdleProperties',
       {
         element,
@@ -114,6 +114,19 @@ function DataObjectTextField(props) {
         }
       }
     );
+
+    // Also update the label of all the references
+    let references = findDataReferences(element, dataObject.id);
+    for (const ref of references) {
+      commandStack.execute('element.updateProperties', {
+        element: ref,
+        moddleElement: ref.businessObject,
+        properties: {
+          'name': value
+        },
+        changed:[ ref ] // everything is already marked as changed, don't recalculate.
+      });
+    }
   };
 
   const getValue = (parameter) => {

--- a/test/spec/DataObjectInterceptorSpec.js
+++ b/test/spec/DataObjectInterceptorSpec.js
@@ -61,6 +61,20 @@ describe('DataObject Interceptor', function() {
     expect(dataObjectRefShape1.businessObject.name).to.equal(dataObjects[0].id);
   }));
 
+  it('should allow you to add a data object to a subprocess', inject(function(canvas, modeling, elementRegistry) {
 
+    // IF - A data object reference is added to a sup-process
+    let subProcessShape = elementRegistry.get('my_subprocess');
+    let subProcess = subProcessShape.businessObject;
+    let dataObjects = findDataObjects(subProcess);
+    expect(dataObjects.length).to.equal(0);
+
+    const dataObjectRefShape = modeling.createShape({ type: 'bpmn:DataObjectReference' },
+      { x: 220, y: 220 }, subProcessShape);
+
+    // THEN - a new data object is visible in that SubProcess
+    dataObjects = findDataObjects(subProcess);
+    expect(dataObjects.length).to.equal(1);
+  }));
 
 });

--- a/test/spec/DataObjectPropsSpec.js
+++ b/test/spec/DataObjectPropsSpec.js
@@ -1,13 +1,15 @@
 import {
   bootstrapPropertiesPanel, changeInput,
   expectSelected,
-  findEntry, findGroupEntry, findSelect,
+  findEntry, findGroupEntry, findInput, findSelect,
 } from './helpers';
 import { BpmnPropertiesPanelModule, BpmnPropertiesProviderModule } from 'bpmn-js-properties-panel';
 import SpiffWorkflowPropertiesProvider from '../../app/spiffworkflow/PropertiesPanel';
+import { inject } from 'bpmn-js/test/helper';
 
 import spiffModdleExtension from '../../app/spiffworkflow/moddle/spiffworkflow.json';
 import TestContainer from 'mocha-test-container-support';
+import { findDataObjects } from '../../app/spiffworkflow/DataObject/DataObjectHelpers';
 
 describe('Properties Panel for Data Objects', function() {
   let xml = require('./bpmn/diagram.bpmn').default;
@@ -46,7 +48,8 @@ describe('Properties Panel for Data Objects', function() {
     expect(selector.length).to.equal(3);
   });
 
-  it('selecting a data object should change the data model.', async function() {
+
+  it('selecting a different data object should change the data model.', async function() {
 
     // IF - a data object reference is selected
     let my_data_ref_1 = await expectSelected('my_data_ref_1');
@@ -62,5 +65,17 @@ describe('Properties Panel for Data Objects', function() {
     expect(businessObject.get('dataObjectRef').id).to.equal('my_third_data_object');
   });
 
+  it('renaming a data object, changes to the label of references', async function() {
+
+    // IF - a process is selected, and the name of a data object is changed.
+    let entry = findEntry('ProcessTest-dataObj-2-id', container);
+    let textInput = findInput('text', entry);
+    changeInput(textInput, 'my_nifty_new_name');
+    let my_data_ref_1 = await expectSelected('my_data_ref_1');
+
+    // THEN - both the data object itself, and the label of any references are updated.
+    expect(my_data_ref_1.businessObject.dataObjectRef.id).to.equal('my_nifty_new_name');
+    expect(my_data_ref_1.businessObject.name).to.equal('my_nifty_new_name');
+  });
 
 });

--- a/test/spec/bpmn/diagram.bpmn
+++ b/test/spec/bpmn/diagram.bpmn
@@ -40,6 +40,11 @@
     <bpmn:dataObject id="my_other_data_object" />
     <bpmn:dataObject id="my_third_data_object" />
     <bpmn:dataObjectReference id="my_data_ref_1" name="my_data_object" dataObjectRef="my_data_object" />
+    <bpmn:sequenceFlow id="Flow_132laxn" sourceRef="Activity_1ph5x7y" targetRef="Event_14wzv4j" />
+    <bpmn:userTask id="Activity_1ph5x7y" name="confirm contentment">
+      <bpmn:incoming>Flow_0q4oys2</bpmn:incoming>
+      <bpmn:outgoing>Flow_132laxn</bpmn:outgoing>
+    </bpmn:userTask>
     <bpmn:dataObjectReference id="my_data_ref_2" name="my_data_object" dataObjectRef="my_data_object">
       <bpmn:extensionElements>
         <camunda:properties>
@@ -49,78 +54,73 @@
       </bpmn:extensionElements>
     </bpmn:dataObjectReference>
     <bpmn:dataObject id="my_data_object" />
-    <bpmn:sequenceFlow id="Flow_132laxn" sourceRef="Activity_1ph5x7y" targetRef="Event_14wzv4j" />
-    <bpmn:userTask id="Activity_1ph5x7y" name="confirm contentment">
-      <bpmn:incoming>Flow_0q4oys2</bpmn:incoming>
-      <bpmn:outgoing>Flow_132laxn</bpmn:outgoing>
-    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ProcessTest">
-      <bpmndi:BPMNShape id="dataInput_2" bpmnElement="happy_index">
-        <dc:Bounds x="762" y="85" width="36" height="50" />
+      <bpmndi:BPMNShape id="dataInput_1" bpmnElement="num_dogs">
+        <dc:Bounds x="172" y="85" width="36" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="738" y="142" width="83" height="14" />
+          <dc:Bounds x="151" y="135" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="dataInput_2" bpmnElement="happy_index">
+        <dc:Bounds x="772" y="65" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="748" y="122" width="83" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0q4oys2_di" bpmnElement="Flow_0q4oys2">
-        <di:waypoint x="540" y="197" />
-        <di:waypoint x="590" y="197" />
+        <di:waypoint x="540" y="187" />
+        <di:waypoint x="590" y="187" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mezzcx_di" bpmnElement="Flow_1mezzcx">
-        <di:waypoint x="215" y="197" />
-        <di:waypoint x="280" y="197" />
+        <di:waypoint x="215" y="187" />
+        <di:waypoint x="280" y="187" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01jg677_di" bpmnElement="Flow_01jg677">
-        <di:waypoint x="380" y="197" />
-        <di:waypoint x="440" y="197" />
+        <di:waypoint x="380" y="187" />
+        <di:waypoint x="440" y="187" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_132laxn_di" bpmnElement="Flow_132laxn">
-        <di:waypoint x="690" y="197" />
-        <di:waypoint x="732" y="197" />
+        <di:waypoint x="690" y="187" />
+        <di:waypoint x="772" y="187" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="179" width="36" height="36" />
+        <dc:Bounds x="179" y="169" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0t7iwfm_di" bpmnElement="Activity_15zz6ya">
-        <dc:Bounds x="280" y="157" width="100" height="80" />
+        <dc:Bounds x="280" y="147" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0h86vbv_di" bpmnElement="my_script_task">
-        <dc:Bounds x="440" y="157" width="100" height="80" />
+        <dc:Bounds x="440" y="147" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataObjectReference_1cezipn_di" bpmnElement="my_data_ref_1">
-        <dc:Bounds x="312" y="275" width="36" height="50" />
+        <dc:Bounds x="312" y="265" width="36" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="292" y="332" width="78" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="dataInput_1" bpmnElement="num_dogs">
-        <dc:Bounds x="179" y="85" width="36" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="158" y="135" width="81" height="14" />
+          <dc:Bounds x="292" y="322" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataObjectReference_08bm72g_di" bpmnElement="my_data_ref_2">
-        <dc:Bounds x="472" y="275" width="36" height="50" />
+        <dc:Bounds x="472" y="265" width="36" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="451" y="332" width="78" height="14" />
+          <dc:Bounds x="451" y="322" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_14wzv4j_di" bpmnElement="Event_14wzv4j">
-        <dc:Bounds x="732" y="179" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1gk19al_di" bpmnElement="Activity_1ph5x7y">
-        <dc:Bounds x="590" y="157" width="100" height="80" />
+        <dc:Bounds x="590" y="147" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14wzv4j_di" bpmnElement="Event_14wzv4j">
+        <dc:Bounds x="772" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="DataOutputAssociation_1uj5jzs_di" bpmnElement="DataOutputAssociation_1uj5jzs">
-        <di:waypoint x="329" y="237" />
-        <di:waypoint x="328" y="275" />
+        <di:waypoint x="329" y="227" />
+        <di:waypoint x="328" y="265" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="DataInputAssociation_0ve9sql_di" bpmnElement="DataInputAssociation_0ve9sql">
-        <di:waypoint x="490" y="275" />
-        <di:waypoint x="490" y="237" />
+        <di:waypoint x="490" y="265" />
+        <di:waypoint x="490" y="227" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/bpmn/empty_diagram.bpmn
+++ b/test/spec/bpmn/empty_diagram.bpmn
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1qnx3d3" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qnx3d3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
   <bpmn:process id="Process_16xfaqc" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:subProcess id="my_subprocess" name="my_subprocess">
+      <bpmn:startEvent id="Event_1u7naip" />
+    </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_16xfaqc">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="159" width="36" height="36" />
+        <dc:Bounds x="179" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11pqp1v_di" bpmnElement="my_subprocess" isExpanded="true">
+        <dc:Bounds x="330" y="90" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u7naip_di" bpmnElement="Event_1u7naip">
+        <dc:Bounds x="370" y="172" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
(IMPORTANT:  Merge User Forms PR First)

Some minor bug fixes that needed squashing:
1. When you rename a DataObject in the properties panel for a process, the labels of all the references should update.
2. Sub-processes should have their own independent list of data objects in the properties panel.