### PR TITLE
use xml element body rather than attribute for business rule task

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionCalledDecision.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionCalledDecision.js
@@ -12,7 +12,7 @@ const SPIFF_PROP = "spiffworkflow:calledDecision"
  *
     <bpmn:businessRuleTask id="Activity_0t218za">
       <bpmn:extensionElements>
-        <spiffworkflow:calledDecision decisionId="my_id" />
+        <spiffworkflow:calledDecision>my_id</spiffworkflow:calledDecision>
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
  *

--- a/app/spiffworkflow/moddle/spiffworkflow.json
+++ b/app/spiffworkflow/moddle/spiffworkflow.json
@@ -32,7 +32,7 @@
       "properties": [
         {
           "name": "decisionId",
-          "isAttr": true,
+          "isBody": true,
           "type": "String"
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "bpmn-js-spiffworkflow",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.7",
+      "name": "bpmn-js-spiffworkflow",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "bpmn-js": "^9.2.2",

--- a/test/spec/BusinessRulePropsSpec.js
+++ b/test/spec/BusinessRulePropsSpec.js
@@ -54,4 +54,17 @@ describe('Business Rule Properties Panel', function() {
     expect(element.decisionId).to.equal('wonderful');
   });
 
+  it('should load up the xml and the value for the called decision should match the xml', async function() {
+    const businessRuleTask = await expectSelected('business_rule_task');
+    let entry = findEntry('extension_called_decision', getPropertiesPanel());
+    const textInput = domQuery('input', entry);
+    expect(textInput.value).to.equal('test_decision');
+
+    // THEN - the script tag in the BPMN Business object / XML is updated as well.
+    let businessObject = getBusinessObject(businessRuleTask);
+    expect(businessObject.extensionElements).to.exist;
+    let element = businessObject.extensionElements.values[0];
+    expect(element.decisionId).to.equal('test_decision');
+  });
+
 });

--- a/test/spec/bpmn/diagram.bpmn
+++ b/test/spec/bpmn/diagram.bpmn
@@ -65,7 +65,7 @@
     <bpmn:sequenceFlow id="Flow_1lu1qyz" sourceRef="business_rule_task" targetRef="Event_14wzv4j" />
     <bpmn:businessRuleTask id="business_rule_task">
       <bpmn:extensionElements>
-        <spiffworkflow:calledDecision decisionId="test_decision" />
+        <spiffworkflow:calledDecision>test_decision</spiffworkflow:calledDecision>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_132laxn</bpmn:incoming>
       <bpmn:outgoing>Flow_1lu1qyz</bpmn:outgoing>


### PR DESCRIPTION
since that is more conventional and because it simplifies spiff lib.