### PR TITLE
Feature/events with payloads

### DIFF
--- a/app/spiffworkflow/errors/index.js
+++ b/app/spiffworkflow/errors/index.js
@@ -1,0 +1,6 @@
+import ErrorPropertiesProvider from './propertiesPanel/ErrorPropertiesProvider';
+
+export default {
+  __init__: ['errorPropertiesProvider'],
+  errorPropertiesProvider: ['type', ErrorPropertiesProvider],
+}

--- a/app/spiffworkflow/errors/propertiesPanel/ErrorPropertiesProvider.js
+++ b/app/spiffworkflow/errors/propertiesPanel/ErrorPropertiesProvider.js
@@ -1,0 +1,49 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getRoot } from '../../helpers';
+import { getArrayForType, getListGroupForType } from '../../eventList.js';
+import { hasEventType,
+  replaceGroup,
+  getSelectorForType,
+  getConfigureGroupForType
+} from '../../eventSelect.js';
+
+const LOW_PRIORITY = 500;
+
+const eventDetails = {
+  'eventType': 'bpmn:Error',
+  'eventDefType': 'bpmn:ErrorEventDefinition',
+  'referenceType': 'errorRef',
+  'idPrefix': 'error',
+};
+
+export default function ErrorPropertiesProvider(
+  propertiesPanel,
+  translate,
+  moddle,
+  commandStack,
+) {
+
+  this.getGroups = function (element) {
+    return function (groups) {
+      if (is(element, 'bpmn:Process') || is(element, 'bpmn:Collaboration')) {
+        const getErrorArray = getArrayForType('bpmn:Error', 'errorRef', 'Error');
+        const errorGroup = getListGroupForType('errors', 'Errors', getErrorArray);
+        groups.push(errorGroup({ element, translate, moddle, commandStack }));
+      } else if (hasEventType(element, 'bpmn:ErrorEventDefinition')) {
+        const getErrorSelector = getSelectorForType(eventDetails);
+        const errorGroup = getConfigureGroupForType(eventDetails, 'Error', true, getErrorSelector);
+        const group = errorGroup({ element, translate, moddle, commandStack });
+        replaceGroup('error', groups, group);
+      }
+      return groups;
+    };
+  };
+  propertiesPanel.registerProvider(LOW_PRIORITY, this);
+}
+
+ErrorPropertiesProvider.$inject = [
+  'propertiesPanel',
+  'translate',
+  'moddle',
+  'commandStack',
+];

--- a/app/spiffworkflow/escalations/index.js
+++ b/app/spiffworkflow/escalations/index.js
@@ -1,0 +1,6 @@
+import EscalationPropertiesProvider from './propertiesPanel/EscalationPropertiesProvider';
+
+export default {
+  __init__: ['escalationPropertiesProvider'],
+  escalationrrorPropertiesProvider: ['type', EscalationPropertiesProvider],
+}

--- a/app/spiffworkflow/escalations/propertiesPanel/EscalationPropertiesProvider.js
+++ b/app/spiffworkflow/escalations/propertiesPanel/EscalationPropertiesProvider.js
@@ -1,0 +1,49 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getRoot } from '../../helpers';
+import { getArrayForType, getListGroupForType } from '../../eventList.js';
+import { hasEventType,
+  replaceGroup,
+  getSelectorForType,
+  getConfigureGroupForType
+} from '../../eventSelect.js';
+
+const LOW_PRIORITY = 500;
+
+const eventDetails = {
+  'eventType': 'bpmn:Escalation',
+  'eventDefType': 'bpmn:EscalationEventDefinition',
+  'referenceType': 'errorRef',
+  'idPrefix': 'error',
+};
+
+export default function EscalationPropertiesProvider(
+  propertiesPanel,
+  translate,
+  moddle,
+  commandStack,
+) {
+
+  this.getGroups = function (element) {
+    return function (groups) {
+      if (is(element, 'bpmn:Process') || is(element, 'bpmn:Collaboration')) {
+        const getEscalationArray = getArrayForType('bpmn:Escalation', 'errorRef', 'Escalation');
+        const errorGroup = getListGroupForType('escalations', 'Escalations', getEscalationArray);
+        groups.push(errorGroup({ element, translate, moddle, commandStack }));
+      } else if (hasEventType(element, 'bpmn:EscalationEventDefinition')) {
+        const getEscalationSelector = getSelectorForType(eventDetails);
+        const errorGroup = getConfigureGroupForType(eventDetails, 'Escalation', true, getEscalationSelector);
+        const group = errorGroup({ element, translate, moddle, commandStack });
+        replaceGroup('error', groups, group);
+      }
+      return groups;
+    };
+  };
+  propertiesPanel.registerProvider(LOW_PRIORITY, this);
+}
+
+EscalationPropertiesProvider.$inject = [
+  'propertiesPanel',
+  'translate',
+  'moddle',
+  'commandStack',
+];

--- a/app/spiffworkflow/eventList.js
+++ b/app/spiffworkflow/eventList.js
@@ -15,7 +15,7 @@ import { getRoot } from './helpers';
  * const signalGroup = createGroupForType('signals', 'Signals', getArray);
  */
 
-function createGroupForType(groupId, label, getArray) {
+function getListGroupForType(groupId, label, getArray) {
 
   return  function (props) {
     const { element, translate, moddle, commandStack } = props;
@@ -160,4 +160,4 @@ function ItemTextField(props) {
   });
 }
 
-export { getArrayForType, createGroupForType };
+export { getArrayForType, getListGroupForType };

--- a/app/spiffworkflow/eventList.js
+++ b/app/spiffworkflow/eventList.js
@@ -1,0 +1,163 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { useService } from 'bpmn-js-properties-panel';
+import {
+  ListGroup,
+  TextFieldEntry,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
+import { getRoot } from './helpers';
+
+/* This function creates a list of a particular event type at the process level using the item list
+ * and add function provided by `getArray`.
+ *
+ * Usage:
+ * const getArray = getArrayForType('bpmn:Signal', 'signalRef', 'Signal');
+ * const signalGroup = createGroupForType('signals', 'Signals', getArray);
+ */
+
+function createGroupForType(groupId, label, getArray) {
+
+  return  function (props) {
+    const { element, translate, moddle, commandStack } = props;
+    const eventArray = {
+      id: groupId,
+      element,
+      label: label,
+      component: ListGroup,
+      ...getArray({ element, moddle, commandStack, translate }),
+    };
+
+    if (eventArray.items) {
+      return eventArray;
+    }
+  }
+}
+
+function getArrayForType(itemType, referenceType, prefix) {
+
+  return function (props) {
+    const { element, moddle, commandStack, translate } = props;
+    const root = getRoot(element.businessObject);
+    const matching = root.rootElements ? root.rootElements.filter(elem => elem.$type === itemType) : [];
+
+    function removeModelReferences(flowElements, match) {
+      flowElements.map(elem => {
+        if (elem.eventDefinitions)
+          elem.eventDefinitions = elem.eventDefinitions.filter(def => def.get(referenceType) != match);
+        else if (elem.flowElements)
+          removeModelReferences(elem.flowElements, match);
+      });
+    }
+
+    function removeElementReferences(children, match) {
+      children.map(child => {
+        if (child.businessObject.eventDefinitions) {
+          const bo = child.businessObject;
+          bo.eventDefinitions = bo.eventDefinitions.filter(def => def.get(referenceType) != match);
+          commandStack.execute('element.updateProperties', {
+            element: child,
+            moddleElement: bo,
+            properties: {}
+          });
+        }
+        if (child.children)
+          removeElementReferences(child.children, match);
+      });
+    }
+
+    function removeFactory(item) {
+      return function (event) {
+        event.stopPropagation();
+        if (root.rootElements) {
+          root.rootElements = root.rootElements.filter(elem => elem != item);
+          // This updates visible elements
+          removeElementReferences(element.children, item);
+          // This handles everything else (eg collapsed subprocesses) but does not update the shapes
+          // I can't figure out how to do that
+          root.rootElements.filter(elem => elem.$type === 'bpmn:Process').map(
+            process => removeModelReferences(process.flowElements, item)
+          );
+          commandStack.execute('element.updateProperties', {
+            element,
+            properties: {},
+          });
+        }
+      }
+    }
+
+    const items = matching.map((item, idx) => {
+      const itemId = `${prefix}-${idx}`;
+      return {
+        id: itemId,
+        label: item.name,
+        entries: getItemEditor({
+          itemId,
+          element,
+          item,
+          commandStack,
+          translate,
+        }),
+        autoFocusEntry: itemId,
+        remove: removeFactory(item),
+      };
+    });
+
+    function add(event) {
+      event.stopPropagation();
+      const item = moddle.create(itemType);
+      item.id = moddle.ids.nextPrefixed(`${prefix}_`);
+      item.name = item.id;
+      if (root.rootElements)
+        root.rootElements.push(item);
+      commandStack.execute('element.updateProperties', {
+        element,
+        properties: {},
+      });
+    };
+
+    return { items, add };
+  }
+}
+
+function getItemEditor(props) {
+  const { itemId, element, item, commandStack, translate } = props;
+  return [
+    {
+      id: `${itemId}-name`,
+      component: ItemTextField,
+      item,
+      commandStack,
+      translate,
+    },
+  ];
+}
+
+function ItemTextField(props) {
+  const { itemId, element, item, commandStack, translate } = props;
+
+  const debounce = useService('debounceInput');
+
+  const setValue = (value) => {
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: item,
+      properties: {
+        id: value,
+        name: value,
+      },
+    });
+  };
+
+  const getValue = () => { return item.id; }
+
+  return TextFieldEntry({
+    element,
+    id: `${itemId}-id-textField`,
+    label: translate('ID'),
+    getValue,
+    setValue,
+    debounce,
+  });
+}
+
+export { getArrayForType, createGroupForType };

--- a/app/spiffworkflow/eventSelect.js
+++ b/app/spiffworkflow/eventSelect.js
@@ -31,7 +31,7 @@ function isThrowingEvent(element) {
   return isAny(element, ['bpmn:EndEvent', 'bpmn:IntermediateThroEvent']);
 }
 
-function getConfigureGroupForType(eventDetails, label, getSelect) {
+function getConfigureGroupForType(eventDetails, label, includeCode, getSelect) {
 
   const { eventType, eventDefType, referenceType, idPrefix } = eventDetails;
 
@@ -51,6 +51,19 @@ function getConfigureGroupForType(eventDetails, label, getSelect) {
         commandStack,
       },
     ];
+
+    if (includeCode) {
+      const codeField = getCodeTextField(eventDetails, `${label} Code`);
+      entries.push({
+        id: `${idPrefix}-code`,
+        element,
+        component: codeField,
+        isEdited: isTextFieldEntryEdited,
+        moddle,
+        commandStack,
+      });
+    }
+
 
     if (isCatchingEvent(element)) {
       entries.push({
@@ -188,6 +201,45 @@ function getTextFieldForExtension(eventDetails, label, description, catching) {
         debounce,
       });
     }
+  }
+}
+
+function getCodeTextField(eventDetails, label) {
+
+  const { eventType, eventDefType, referenceType, idPrefix } = eventDetails;
+
+  return function (props) {
+
+    const { element, moddle, commandStack } = props;
+    const translate = useService('translate');
+    const debounce = useService('debounceInput');
+    const attrName = `${idPrefix}Code`;
+
+    const getEvent = () => {
+      const eventDef = element.businessObject.eventDefinitions.find(v => v.$type == eventDefType);
+      const bpmnEvent = eventDef.get(referenceType);
+      return bpmnEvent;
+    };
+
+    const getValue = () => {
+      const bpmnEvent = getEvent();
+      return (bpmnEvent) ? bpmnEvent.get(attrName) : null;
+    };
+
+    const setValue = (value) => {
+      const bpmnEvent = getEvent();
+      if (bpmnEvent)
+        bpmnEvent.set(attrName, value);
+    };
+
+    return TextFieldEntry({
+      element,
+      id: `${idPrefix}-code-value`,
+      label: translate(label),
+      getValue,
+      setValue,
+      debounce,
+    });
   }
 }
 

--- a/app/spiffworkflow/eventSelect.js
+++ b/app/spiffworkflow/eventSelect.js
@@ -28,7 +28,7 @@ function isCatchingEvent(element) {
 }
 
 function isThrowingEvent(element) {
-  return isAny(element, ['bpmn:EndEvent', 'bpmn:IntermediateThroEvent']);
+  return isAny(element, ['bpmn:EndEvent', 'bpmn:IntermediateThrowEvent']);
 }
 
 function getConfigureGroupForType(eventDetails, label, includeCode, getSelect) {
@@ -157,6 +157,11 @@ function getTextFieldForExtension(eventDetails, label, description, catching) {
     };
 
     const getValue = () => {
+      // I've put the variable name (and payload) on the event for consistency with messages.
+      // However, when I think about this, I wonder if it shouldn't be on the event definition.
+      // I think that's something we should address in the future.
+      // Creating a payload and defining access to it are both process-specific, and that's an argument for leaving
+      // it in the event definition
       const bpmnEvent = getEvent();
       if (bpmnEvent && bpmnEvent.extensionElements) {
         const extension = bpmnEvent.extensionElements.get('values').find(ext => ext.$instanceOf(extensionName));

--- a/app/spiffworkflow/eventSelect.js
+++ b/app/spiffworkflow/eventSelect.js
@@ -1,0 +1,194 @@
+import { is, isAny } from 'bpmn-js/lib/util/ModelUtil';
+import { useService } from 'bpmn-js-properties-panel';
+import {
+  ListGroup,
+  TextFieldEntry,
+  TextAreaEntry,
+  SelectEntry,
+  isTextFieldEntryEdited
+} from '@bpmn-io/properties-panel';
+import { getRoot } from './helpers';
+
+function hasEventType(element, eventType) {
+  const events = element.businessObject.eventDefinitions;
+  return events && events.filter(item => is(item, eventType)).length > 0;
+}
+
+function replaceGroup(groupId, groups, group) {
+  const idx = groups.map(g => g.id).indexOf(groupId);
+  if (idx > -1)
+    groups.splice(idx, 1, group);
+  else
+    groups.push(group);
+  group.shouldOpen = true;
+}
+
+function isCatchingEvent(element) {
+  return isAny(element, ['bpmn:StartEvent', 'bpmn:IntermediateCatchEvent', 'bpmn:BoundaryEvent']);
+}
+
+function isThrowingEvent(element) {
+  return isAny(element, ['bpmn:EndEvent', 'bpmn:IntermediateThroEvent']);
+}
+
+function getConfigureGroupForType(eventDetails, label, getSelect) {
+
+  const { eventType, eventDefType, referenceType, idPrefix } = eventDetails;
+
+  return function (props) {
+    const { element, translate, moddle, commandStack } = props;
+
+    const variableName = getTextFieldForExtension(eventDetails, 'Variable Name', 'The name of the variable to store the payload in', true);
+    const payloadDefinition = getTextFieldForExtension(eventDetails, 'Payload', 'The expression to create the payload with', false);
+
+    const entries = [
+      {
+        id: `${idPrefix}-select`,
+        element,
+        component: getSelect,
+        isEdited: isTextFieldEntryEdited,
+        moddle,
+        commandStack,
+      },
+    ];
+
+    if (isCatchingEvent(element)) {
+      entries.push({
+        id: `${idPrefix}-variable`,
+        element,
+        component: variableName,
+        isEdited: isTextFieldEntryEdited,
+        moddle,
+        commandStack,
+      });
+    } else if (isThrowingEvent(element)) {
+      entries.push({
+        id: `${idPrefix}-payload`,
+        element,
+        component: payloadDefinition,
+        isEdited: isTextFieldEntryEdited,
+        moddle,
+        commandStack,
+      });
+    };
+    return {
+      id: `${idPrefix}-group`,
+      label: label,
+      entries,
+    }
+  }
+}
+
+function getSelectorForType(eventDetails) {
+
+  const { eventType, eventDefType, referenceType, idPrefix } = eventDetails;
+
+  return function (props) {
+    const { element, translate, moddle, commandStack } = props;
+    const debounce = useService('debounceInput');
+    const root = getRoot(element.businessObject);
+
+    const getValue = () => {
+      const eventDef = element.businessObject.eventDefinitions.find(v => v.$type == eventDefType);
+      return (eventDef && eventDef.get(referenceType)) ? eventDef.get(referenceType).id : '';
+    };
+
+    const setValue = (value) => {
+      const bpmnEvent = root.rootElements.find(e => e.id == value);
+      // not sure how to handle multiple event definitions
+      const eventDef = element.businessObject.eventDefinitions.find(v => v.$type == eventDefType);
+      // really not sure what to do here if one of these can't be found either
+      if (bpmnEvent && eventDef)
+        eventDef.set(referenceType, bpmnEvent);
+      commandStack.execute('element.updateProperties', {
+        element,
+        moddleElement: element.businessObject,
+        properties: {},
+      });
+    };
+
+    const getOptions = (val) => {
+      const matching = root.rootElements ? root.rootElements.filter(elem => elem.$type === eventType) : [];
+      const options = [];
+      matching.map(option => options.push({label: option.name, value: option.id}));
+      return options;
+    }
+
+    return SelectEntry({
+      id: `${idPrefix}-select`,
+      element,
+      description: 'Select item',
+      getValue,
+      setValue,
+      getOptions,
+      debounce,
+    });
+  }
+}
+
+function getTextFieldForExtension(eventDetails, label, description, catching) {
+
+  const { eventType, eventDefType, referenceType, idPrefix } = eventDetails;
+
+  return function (props) {
+    const { element, moddle, commandStack } = props;
+    const debounce = useService('debounceInput');
+    const translate = useService('translate');
+    const root = getRoot(element.businessObject);
+    const extensionName = (catching) ? 'spiffworkflow:variableName' : 'spiffworkflow:payloadExpression';
+
+    const getEvent = () => {
+      const eventDef = element.businessObject.eventDefinitions.find(v => v.$type == eventDefType);
+      const bpmnEvent = eventDef.get(referenceType);
+      return bpmnEvent;
+    };
+
+    const getValue = () => {
+      const bpmnEvent = getEvent();
+      if (bpmnEvent && bpmnEvent.extensionElements) {
+        const extension = bpmnEvent.extensionElements.get('values').find(ext => ext.$instanceOf(extensionName));
+        return (extension) ? extension.value : null;
+      }
+    }
+
+    const setValue = (value)  => {
+      const bpmnEvent = getEvent();
+      if (bpmnEvent) {
+        if (!bpmnEvent.extensionElements)
+          bpmnEvent.extensionElements = moddle.create('bpmn:ExtensionElements');
+        const extensions = bpmnEvent.extensionElements.get('values');
+        const extension = extensions.find(ext => ext.$instanceOf(extensionName));
+        if (!extension) {
+          const newExt = moddle.create(extensionName);
+          newExt.value = value;
+          extensions.push(newExt);
+        } else
+          extension.value = value;
+      } // not sure what to do if the event hasn't been set
+    };
+
+    if (catching) {
+      return TextFieldEntry({
+        element,
+        id: `${idPrefix}-variable-name`,
+        description: description,
+        label: translate(label),
+        getValue,
+        setValue,
+        debounce,
+      });
+    } else {
+      return TextAreaEntry({
+        element,
+        id: `${idPrefix}-payload-expression`,
+        description: description,
+        label: translate(label),
+        getValue,
+        setValue,
+        debounce,
+      });
+    }
+  }
+}
+
+export { hasEventType, getSelectorForType, getConfigureGroupForType, replaceGroup };

--- a/app/spiffworkflow/helpers.js
+++ b/app/spiffworkflow/helpers.js
@@ -12,3 +12,27 @@ export function removeExtensionElementsIfEmpty(moddleElement) {
     moddleElement.extensionElements = null;
   }
 }
+
+/**
+ * loops up until it can find the root.
+ * @param element
+ */
+export function getRoot(businessObject, moddle) {
+  // HACK: get the root element. need a more formal way to do this
+  if (moddle) {
+    for (const elementId in moddle.ids._seed.hats) {
+      if (elementId.startsWith('Definitions_')) {
+        return moddle.ids._seed.hats[elementId];
+      }
+    }
+  } else {
+    // todo: Do we want businessObject to be a shape or moddle object?
+    if (businessObject.$type === 'bpmn:Definitions') {
+      return businessObject;
+    }
+    if (typeof businessObject.$parent !== 'undefined') {
+      return getRoot(businessObject.$parent);
+    }
+  }
+  return businessObject;
+}

--- a/app/spiffworkflow/index.js
+++ b/app/spiffworkflow/index.js
@@ -9,6 +9,9 @@ import DataObjectPropertiesProvider from './DataObject/propertiesPanel/DataObjec
 import ConditionsPropertiesProvider from './conditions/propertiesPanel/ConditionsPropertiesProvider';
 import ExtensionsPropertiesProvider from './extensions/propertiesPanel/ExtensionsPropertiesProvider';
 import MessagesPropertiesProvider from './messages/propertiesPanel/MessagesPropertiesProvider';
+import SignalPropertiesProvider from './signals/propertiesPanel/SignalPropertiesProvider';
+import ErrorPropertiesProvider from './errors/propertiesPanel/ErrorPropertiesProvider';
+import EscalationPropertiesProvider from './escalations/propertiesPanel/EscalationPropertiesProvider';
 import CallActivityPropertiesProvider from './callActivity/propertiesPanel/CallActivityPropertiesProvider';
 import StandardLoopPropertiesProvider from './loops/propertiesPanel/StandardLoopPropertiesProvider';
 import MultiInstancePropertiesProvider from './loops/propertiesPanel/MultiInstancePropertiesProvider';
@@ -22,6 +25,9 @@ export default {
     'conditionsPropertiesProvider',
     'extensionsPropertiesProvider',
     'messagesPropertiesProvider',
+    'signalPropertiesProvider',
+    'errorPropertiesProvider',
+    'escalationPropertiesProvider',
     'callActivityPropertiesProvider',
     'ioPalette',
     'ioRules',
@@ -36,6 +42,9 @@ export default {
   dataObjectPropertiesProvider: ['type', DataObjectPropertiesProvider],
   conditionsPropertiesProvider: ['type', ConditionsPropertiesProvider],
   extensionsPropertiesProvider: ['type', ExtensionsPropertiesProvider],
+  signalPropertiesProvider: ['type', SignalPropertiesProvider],
+  errorPropertiesProvider: ['type', ErrorPropertiesProvider],
+  escalationPropertiesProvider: ['type', EscalationPropertiesProvider],
   messagesPropertiesProvider: ['type', MessagesPropertiesProvider],
   callActivityPropertiesProvider: ['type', CallActivityPropertiesProvider],
   ioPalette: ['type', IoPalette],

--- a/app/spiffworkflow/moddle/spiffworkflow.json
+++ b/app/spiffworkflow/moddle/spiffworkflow.json
@@ -219,6 +219,28 @@
           "type": "string"
         }
       ]
+    },
+    {
+      "name": "payloadExpression",
+      "superClass": [ "Element" ],
+      "properties": [
+        {
+          "name": "value",
+          "isBody": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "variableName",
+      "superClass": [ "Element" ],
+      "properties": [
+        {
+          "name": "value",
+          "isBody": true,
+          "type": "String"
+        }
+      ]
     }
   ]
 }

--- a/app/spiffworkflow/signals/index.js
+++ b/app/spiffworkflow/signals/index.js
@@ -1,0 +1,6 @@
+import SignalPropertiesProvider from './propertiesPanel/SignalPropertiesProvider';
+
+export default {
+  __init__: ['signalPropertiesProvider'],
+  signalPropertiesProvider: ['type', SignalPropertiesProvider],
+}

--- a/app/spiffworkflow/signals/propertiesPanel/SignalPropertiesProvider.js
+++ b/app/spiffworkflow/signals/propertiesPanel/SignalPropertiesProvider.js
@@ -1,0 +1,49 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getRoot } from '../../helpers';
+import { getArrayForType, getListGroupForType } from '../../eventList.js';
+import { hasEventType,
+  replaceGroup,
+  getSelectorForType,
+  getConfigureGroupForType
+} from '../../eventSelect.js';
+
+const LOW_PRIORITY = 500;
+
+const eventDetails = {
+  'eventType': 'bpmn:Signal',
+  'eventDefType': 'bpmn:SignalEventDefinition',
+  'referenceType': 'signalRef',
+  'idPrefix': 'signal',
+};
+
+export default function SignalPropertiesProvider(
+  propertiesPanel,
+  translate,
+  moddle,
+  commandStack,
+) {
+
+  this.getGroups = function (element) {
+    return function (groups) {
+      if (is(element, 'bpmn:Process') || is(element, 'bpmn:Collaboration')) {
+        const getSignalArray = getArrayForType('bpmn:Signal', 'signalRef', 'Signal');
+        const signalGroup = getListGroupForType('signals', 'Signals', getSignalArray);
+        groups.push(signalGroup({ element, translate, moddle, commandStack }));
+      } else if (hasEventType(element, 'bpmn:SignalEventDefinition')) {
+        const getSignalSelector = getSelectorForType(eventDetails);
+        const signalGroup = getConfigureGroupForType(eventDetails, 'Signal', false, getSignalSelector);
+        const group = signalGroup({ element, translate, moddle, commandStack });
+        replaceGroup('signal', groups, group);
+      }
+      return groups;
+    };
+  };
+  propertiesPanel.registerProvider(LOW_PRIORITY, this);
+}
+
+SignalPropertiesProvider.$inject = [
+  'propertiesPanel',
+  'translate',
+  'moddle',
+  'commandStack',
+];


### PR DESCRIPTION
This adds `Signals`, `Escalations` and `Errors` to the process or collaboration panel and makes it possible to define payloads for throw events and the variable name to store the received payload in for catch events.  The UI is the same as for messages, but created with some helpers for generic list creation and selection.