### PR TITLE
allow attaching pre/post scripts to MI task or instance tasks

### DIFF
--- a/app/spiffworkflow/moddle/spiffworkflow.json
+++ b/app/spiffworkflow/moddle/spiffworkflow.json
@@ -241,6 +241,20 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "scriptsOnInstances",
+      "extends": [
+        "bpmn:MultiInstanceLoopCharacteristics",
+        "bpmn:StandardLoopCharacteristics"
+      ],
+      "properties": [
+        {
+          "name": "scriptsOnInstances",
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds a checkbox to the spiff scripts panel that allows the option of ataching the pre/post scripts to the MI instance rather than the controlling task.