### PR TITLE
Assume established naming conventions over requiring a form schema an…

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -160,8 +160,8 @@ bpmnModeler.on('spiff.dmn.edit', (newEvent) => {
  * Also handy to get a list of available files that can be used in a given
  * context, say json files for a form, or a DMN file for a BusinessRuleTask
  */
-bpmnModeler.on('spiff.json_files.requested', (event) => {
-  event.eventBus.fire('spiff.json_files.returned', {
+bpmnModeler.on('spiff.json_schema_files.requested', (event) => {
+  event.eventBus.fire('spiff.json_schema_files.returned', {
     options: [
       { label: 'pizza_form.json', value: 'pizza_form.json' },
       { label: 'credit_card_form.json', value: 'credit_card_form.json' },

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionLaunchButton.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionLaunchButton.js
@@ -8,7 +8,7 @@ import {getExtensionValue, setExtensionValue} from '../extensionHelpers';
  * update the value and send it back.
  */
 export function SpiffExtensionLaunchButton(props) {
-  const { element, name, event, listenEvent } = props;
+  const { element, name, event, listenEvent, listenFunction } = props;
   const eventBus = useService('eventBus');
   return HeaderButton({
     className: 'spiffworkflow-properties-panel-button',
@@ -28,7 +28,11 @@ export function SpiffExtensionLaunchButton(props) {
         const { commandStack, moddle } = props;
         // Listen for a response, to update the script.
         eventBus.once(listenEvent, (response) => {
-          setExtensionValue(element, name, response.value, moddle, commandStack);
+          if(listenFunction) {
+            listenFunction(element, name, response.value, moddle, commandStack);
+          } else {
+            setExtensionValue(element, name, response.value, moddle, commandStack);
+          }
         });
       }
 

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect.js
@@ -5,10 +5,10 @@ import {
   setExtensionValue,
 } from '../extensionHelpers';
 
-const spiffExtensionOptions = {};
+export const spiffExtensionOptions = {};
 
 export const OPTION_TYPE = {
-  json_files: 'json_files',
+  json_schema_files: 'json_schema_files',
   dmn_files: 'dmn_files',
 };
 
@@ -52,6 +52,10 @@ export function SpiffExtensionSelect(props) {
   }
   const getOptions = () => {
     const optionList = [];
+    optionList.push({
+      label: '',
+      value: '',
+    });
     if (
       optionType in spiffExtensionOptions &&
       spiffExtensionOptions[optionType] !== null
@@ -81,7 +85,7 @@ export function SpiffExtensionSelect(props) {
 function requestOptions(eventBus, element, commandStack, optionType) {
   // Little backwards, but you want to assure you are ready to catch, before you throw
   // or you risk a race condition.
-  eventBus.once(`spiff.${optionType}.returned`, (event) => {
+  eventBus.on(`spiff.${optionType}.returned`, (event) => {
     spiffExtensionOptions[optionType] = event.options;
   });
   eventBus.fire(`spiff.${optionType}.requested`, { eventBus });

--- a/test/spec/UserTaskPropsSpec.js
+++ b/test/spec/UserTaskPropsSpec.js
@@ -79,9 +79,10 @@ describe('Properties Panel for User Tasks', function () {
     const entry = findEntry('extension_formJsonSchemaFilename', group);
     const selectList = findSelect(entry);
     expect(selectList).to.exist;
-    expect(selectList.options.length).to.equal(4);
-    expect(selectList.options[0].label).to.equal('pizza_form.json');
-    expect(selectList.options[1].label).to.equal('credit_card_form.json');
+    expect(selectList.options.length).to.equal(5); // including the empty option
+    expect(selectList.options[0].label).to.equal('');
+    expect(selectList.options[1].label).to.equal('pizza_form.json');
+    expect(selectList.options[2].label).to.equal('credit_card_form.json');
 
     changeInput(selectList, 'pizza_form.json');
 


### PR DESCRIPTION
Assume established naming conventions over requiring a form schema and ui schema each time as separate inputs. Making this one dropdown for the user form instead of two.  Assure there is always an empty option in the dropdown list, so people have the ability to re-select nothing if they choose to do so. Provide a way to override the default behavior when a response is provided back to a generic launch button.