### PR TITLE
No param sort

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.js
@@ -1,5 +1,6 @@
 import {
-  ListGroup,
+    ListGroup,
+    Group,
   CheckboxEntry,
   isCheckboxEntryEdited,
 } from '@bpmn-io/properties-panel';
@@ -88,6 +89,7 @@ export default function ExtensionsPropertiesProvider(
         );
       }
 
+	console.log("groups:"); console.log(groups);
       return groups;
     };
   };
@@ -435,7 +437,8 @@ function createServiceGroup(element, translate, moddle, commandStack) {
       {
         id: 'serviceTaskParameters',
         label: translate('Parameters'),
-        component: ListGroup,
+          component: ListGroup,
+	  shouldSort: false,
         ...ServiceTaskParameterArray({
           element,
           moddle,

--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.js
@@ -1,6 +1,5 @@
 import {
-    ListGroup,
-    Group,
+  ListGroup,
   CheckboxEntry,
   isCheckboxEntryEdited,
 } from '@bpmn-io/properties-panel';
@@ -89,7 +88,6 @@ export default function ExtensionsPropertiesProvider(
         );
       }
 
-	console.log("groups:"); console.log(groups);
       return groups;
     };
   };
@@ -437,8 +435,8 @@ function createServiceGroup(element, translate, moddle, commandStack) {
       {
         id: 'serviceTaskParameters',
         label: translate('Parameters'),
-          component: ListGroup,
-	  shouldSort: false,
+        component: ListGroup,
+        shouldSort: false,
         ...ServiceTaskParameterArray({
           element,
           moddle,

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
@@ -69,7 +69,7 @@ function getServiceTaskParameterModdleElements(shapeElement) {
   if (serviceTaskOperatorModdleElement) {
     const { parameterList } = serviceTaskOperatorModdleElement;
     if (parameterList) {
-      return parameterList.parameters.sort((a, b) => a.id.localeCompare(b.id));
+      return parameterList.parameters;
     }
   }
   return [];

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
@@ -43,8 +43,7 @@ const SERVICE_TASK_PARAMETER_ELEMENT_NAME = `${SPIFFWORKFLOW_XML_NAMESPACE}:Para
 function requestServiceTaskOperators(eventBus, element, commandStack) {
   eventBus.fire('spiff.service_tasks.requested', { eventBus });
   eventBus.on('spiff.service_tasks.returned', (event) => {
-      if (event.serviceTaskOperators.length > 0) {
-	  console.log("requestServiceTaskOperators:"); console.log(event.serviceTaskOperators);
+    if (event.serviceTaskOperators.length > 0) {
       serviceTaskOperators = event.serviceTaskOperators;
     }
   });
@@ -67,8 +66,7 @@ function getServiceTaskParameterModdleElements(shapeElement) {
     getServiceTaskOperatorModdleElement(shapeElement);
   if (serviceTaskOperatorModdleElement) {
     const { parameterList } = serviceTaskOperatorModdleElement;
-      if (parameterList) {
-	  console.log("getServiceTaskParameterModdleElements"); console.log(parameterList.parameters);
+    if (parameterList) {
       return parameterList.parameters;
     }
   }
@@ -154,7 +152,6 @@ export function ServiceTaskOperatorSelect(props) {
       }
     }
 
-      console.log("setValue:"); console.log(newParameterList);
     newServiceTaskOperatorModdleElement.parameterList = newParameterList;
 
     const newExtensionValues = extensions.get('values').filter((extValue) => {
@@ -216,7 +213,6 @@ export function ServiceTaskParameterArray(props) {
       };
     }
   );
-    console.log("ServiceTaskParameterArray:"); console.log(items);
   return { items };
 }
 

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
@@ -43,10 +43,9 @@ const SERVICE_TASK_PARAMETER_ELEMENT_NAME = `${SPIFFWORKFLOW_XML_NAMESPACE}:Para
 function requestServiceTaskOperators(eventBus, element, commandStack) {
   eventBus.fire('spiff.service_tasks.requested', { eventBus });
   eventBus.on('spiff.service_tasks.returned', (event) => {
-    if (event.serviceTaskOperators.length > 0) {
-      serviceTaskOperators = event.serviceTaskOperators.sort((a, b) =>
-        a.id.localeCompare(b.id)
-      );
+      if (event.serviceTaskOperators.length > 0) {
+	  console.log("requestServiceTaskOperators:"); console.log(event.serviceTaskOperators);
+      serviceTaskOperators = event.serviceTaskOperators;
     }
   });
 }
@@ -68,7 +67,8 @@ function getServiceTaskParameterModdleElements(shapeElement) {
     getServiceTaskOperatorModdleElement(shapeElement);
   if (serviceTaskOperatorModdleElement) {
     const { parameterList } = serviceTaskOperatorModdleElement;
-    if (parameterList) {
+      if (parameterList) {
+	  console.log("getServiceTaskParameterModdleElements"); console.log(parameterList.parameters);
       return parameterList.parameters;
     }
   }
@@ -154,6 +154,7 @@ export function ServiceTaskOperatorSelect(props) {
       }
     }
 
+      console.log("setValue:"); console.log(newParameterList);
     newServiceTaskOperatorModdleElement.parameterList = newParameterList;
 
     const newExtensionValues = extensions.get('values').filter((extValue) => {
@@ -215,6 +216,7 @@ export function ServiceTaskParameterArray(props) {
       };
     }
   );
+    console.log("ServiceTaskParameterArray:"); console.log(items);
   return { items };
 }
 


### PR DESCRIPTION
Fix for [spiff-arena issue #476 - ](https://github.com/sartography/spiff-arena/issues/476) - took out some sorts that were not needed and set the `ListGroup` component not to sort its list items. This only fixes the issue for newly created service tasks. Existing service tasks already have the sorted order written to the xml. Not sure if it would be worth trying to migrate, but if we do I'd like to look at updating when service task params change, etc as well - so ideally a separate effort.