### PR TITLE
remove-ext-opt-cache

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect.js
@@ -1,9 +1,6 @@
 import { SelectEntry } from '@bpmn-io/properties-panel';
 import { useService } from 'bpmn-js-properties-panel';
-import {
-  getExtensionValue,
-  setExtensionValue,
-} from '../extensionHelpers';
+import { getExtensionValue, setExtensionValue } from '../extensionHelpers';
 
 export const spiffExtensionOptions = {};
 
@@ -43,13 +40,6 @@ export function SpiffExtensionSelect(props) {
     setExtensionValue(element, name, value, moddle, commandStack);
   };
 
-  if (
-    !(optionType in spiffExtensionOptions) ||
-    spiffExtensionOptions[optionType] === null
-  ) {
-    spiffExtensionOptions[optionType] = null;
-    requestOptions(eventBus, element, commandStack, optionType);
-  }
   const getOptions = () => {
     const optionList = [];
     optionList.push({
@@ -69,6 +59,11 @@ export function SpiffExtensionSelect(props) {
     }
     return optionList;
   };
+
+  // always call this code and let the caller determine how to deal with it.
+  // this is to avoid state loading issues with react where it doesn't clear out the variable.
+  spiffExtensionOptions[optionType] = null;
+  requestOptions(eventBus, element, commandStack, optionType);
 
   return SelectEntry({
     id: `extension_${name}`,

--- a/test/spec/BusinessRulePropsSpec.js
+++ b/test/spec/BusinessRulePropsSpec.js
@@ -33,7 +33,6 @@ describe('Business Rule Properties Panel', function () {
     })
   );
 
-
   const return_files = (event) => {
     event.eventBus.fire('spiff.dmn_files.returned', {
       options: [
@@ -42,46 +41,54 @@ describe('Business Rule Properties Panel', function () {
         { label: 'Test Decision', value: 'test_decision' },
       ],
     });
-  }
+  };
 
   it('should display a dropdown to select from available decision tables', async function () {
     const modeler = getBpmnJS();
     modeler.get('eventBus').once('spiff.dmn_files.requested', return_files);
     expectSelected('business_rule_task');
     // THEN - a properties panel exists with a section for editing that script
-    const entry = findEntry('extension_spiffworkflow:CalledDecisionId', getPropertiesPanel());
+    const entry = findEntry(
+      'extension_spiffworkflow:CalledDecisionId',
+      getPropertiesPanel()
+    );
     expect(entry, 'No Entry').to.exist;
     const selectList = findSelect(entry);
     expect(selectList, 'No Select').to.exist;
+    modeler.get('eventBus').off('spiff.dmn_files.requested', return_files);
   });
 
   it('should update the spiffworkflow:calledDecisionId tag when you modify the called decision select box', async function () {
     // IF - a script tag is selected, and you change the script in the properties panel
     const modeler = getBpmnJS();
-    modeler.get('eventBus').once('spiff.dmn_files.requested', return_files);
+    modeler.get('eventBus').on('spiff.dmn_files.requested', return_files);
     const businessRuleTask = await expectSelected('business_rule_task');
     const entry = findEntry('extension_CalledDecisionId', getPropertiesPanel());
     const selectList = findSelect(entry);
     changeInput(selectList, 'Decision_Pizza_Price');
 
-    // THEN - the script tag in the BPMN Business object / XML is updated as well.
+    // THEN - the decision id in the BPMN Business object / XML is updated as well.
     const businessObject = getBusinessObject(businessRuleTask);
     expect(businessObject.extensionElements).to.exist;
     const element = businessObject.extensionElements.values[0];
     expect(element.value).to.equal('Decision_Pizza_Price');
+    modeler.get('eventBus').off('spiff.dmn_files.requested', return_files);
   });
 
   it('should load up the xml and the value for the called decision should match the xml', async function () {
+    const modeler = getBpmnJS();
+    modeler.get('eventBus').on('spiff.dmn_files.requested', return_files);
     const businessRuleTask = await expectSelected('business_rule_task');
     const entry = findEntry('extension_CalledDecisionId', getPropertiesPanel());
     const selectList = findSelect(entry);
-    expect(selectList.value, "initial value is wrong").to.equal('test_decision');
+    expect(selectList.value, 'initial value is wrong').to.equal(
+      'test_decision'
+    );
 
-    // THEN - the script tag in the BPMN Business object / XML is updated as well.
     const businessObject = getBusinessObject(businessRuleTask);
     expect(businessObject.extensionElements).to.exist;
     const element = businessObject.extensionElements.values[0];
     expect(element.value).to.equal('test_decision');
+    modeler.get('eventBus').off('spiff.dmn_files.requested', return_files);
   });
-
 });

--- a/test/spec/DataStoreReferenceSpec.js
+++ b/test/spec/DataStoreReferenceSpec.js
@@ -1,157 +1,205 @@
 import TestContainer from 'mocha-test-container-support';
 import {
-    BpmnPropertiesPanelModule,
-    BpmnPropertiesProviderModule,
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
 } from 'bpmn-js-properties-panel';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
-import {
-    bootstrapPropertiesPanel,
-    changeInput,
-    expectSelected,
-    findGroupEntry,
-    findEntry,
-    findSelect,
-    getPropertiesPanel
-} from './helpers';
-
 import { getBpmnJS, inject } from 'bpmn-js/test/helper';
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  expectSelected,
+  findGroupEntry,
+  findEntry,
+  findSelect,
+  getPropertiesPanel,
+} from './helpers';
 
 import spiffModdleExtension from '../../app/spiffworkflow/moddle/spiffworkflow.json';
 import DataStoreReference from '../../app/spiffworkflow/DataStoreReference';
 import DataStoreInterceptor from '../../app/spiffworkflow/DataStoreReference/DataStoreInterceptor';
 
 const return_datastores = (event) => {
-    event.eventBus.fire('spiff.data_stores.returned', {
-        options: [
-            { id: 'countriesID', type: 'json', name: 'countries', clz: 'JSONDataStore' },
-            { id: 'foodsID', type: 'kkv', name: 'foods', clz: 'JSONDataStore' }
-        ],
-    });
-}
+  event.eventBus.fire('spiff.data_stores.returned', {
+    options: [
+      {
+        id: 'countriesID',
+        type: 'json',
+        name: 'countries',
+        clz: 'JSONDataStore',
+      },
+      { id: 'foodsID', type: 'kkv', name: 'foods', clz: 'JSONDataStore' },
+    ],
+  });
+};
 
 describe('Data Source Reference Test cases', function () {
-    const xml = require('./bpmn/data_store.bpmn').default;
-    let container;
+  const xml = require('./bpmn/data_store.bpmn').default;
+  let container;
 
-    beforeEach(function () {
-        container = TestContainer.get(this);
-    });
+  beforeEach(function () {
+    container = TestContainer.get(this);
+  });
 
-    beforeEach(
-        bootstrapPropertiesPanel(xml, {
-            container,
-            debounceInput: false,
-            additionalModules: [
-                DataStoreReference,
-                DataStoreInterceptor,
-                BpmnPropertiesPanelModule,
-                BpmnPropertiesProviderModule,
-            ],
-            moddleExtensions: {
-                spiffworkflow: spiffModdleExtension,
-            },
-        })
+  beforeEach(
+    bootstrapPropertiesPanel(xml, {
+      container,
+      debounceInput: false,
+      additionalModules: [
+        DataStoreReference,
+        DataStoreInterceptor,
+        BpmnPropertiesPanelModule,
+        BpmnPropertiesProviderModule,
+      ],
+      moddleExtensions: {
+        spiffworkflow: spiffModdleExtension,
+      },
+    })
+  );
+
+  it('should display the custom data store properties group - DataStoreReference element', async function () {
+    // We Select a DataStoreReference element
+    const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
+    expect(shapeElement, "I can't find DataStoreReference element").to.exist;
+
+    // Lets Check if the custom properties group is displayed
+    const customGroup = findGroupEntry(
+      'custom-datastore-properties',
+      container
     );
+    expect(customGroup).to.exist;
+    const entry = findEntry('selectDataStore', container);
+    expect(entry).to.exist;
+  });
 
-    it('should display the custom data store properties group - DataStoreReference element', async function () {
-        // We Select a DataStoreReference element
-        const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
-        expect(shapeElement, "I can't find DataStoreReference element").to.exist;
+  it('should list data sources from aa api response and append it to select - DataStoreReference element', async function () {
+    const modeler = getBpmnJS();
+    modeler
+      .get('eventBus')
+      .once('spiff.data_stores.requested', return_datastores);
 
-        // Lets Check if the custom properties group is displayed
-        const customGroup = findGroupEntry('custom-datastore-properties', container);
-        expect(customGroup).to.exist;
-        const entry = findEntry('selectDataStore', container);
-        expect(entry).to.exist;
-    });
+    // We Select a DataStoreReference element
+    const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
+    expect(shapeElement, "I can't find DataStoreReference element").to.exist;
 
-    it('should list data sources from aa api response and append it to select - DataStoreReference element', async function () {
-        const modeler = getBpmnJS();
-        modeler.get('eventBus').once('spiff.data_stores.requested', return_datastores);
+    // Interact with the DataStoreSelect component
+    const selectGroup = findGroupEntry(
+      'custom-datastore-properties',
+      container
+    );
+    expect(selectGroup).to.exist;
 
-        // We Select a DataStoreReference element
-        const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
-        expect(shapeElement, "I can't find DataStoreReference element").to.exist;
+    const entry = findEntry('selectDataStore', getPropertiesPanel());
+    expect(entry).to.exist;
 
-        // Interact with the DataStoreSelect component
-        const selectGroup = findGroupEntry('custom-datastore-properties', container)
-        expect(selectGroup).to.exist;
+    // Verification if the dataStoreRef attribute is updated
+    const selector = findSelect(entry);
+    expect(selector.length).to.equal(3);
+    expect(selector[1].value === 'foodsID');
+    expect(selector[2].value === 'countriesID');
 
-        const entry = findEntry('selectDataStore', getPropertiesPanel());
-        expect(entry).to.exist;
+    modeler
+      .get('eventBus')
+      .off('spiff.data_stores.requested', return_datastores);
+  });
 
-        // Verification if the dataStoreRef attribute is updated
-        let selector = findSelect(entry);
-        expect(selector.length).to.equal(3);
-        expect(selector[1].value === 'foodsID');
-        expect(selector[2].value === 'countriesID');
-    });
+  it('should update dataStoreRef after a select event && should add new DataStore in the level of process definition - DataStoreReference element', async function () {
+    const modeler = getBpmnJS();
+    modeler
+      .get('eventBus')
+      .once('spiff.data_stores.requested', return_datastores);
 
-    it('should update dataStoreRef after a select event && should add new DataStore in the level of process definition - DataStoreReference element', async function () {
-        const modeler = getBpmnJS();
-        modeler.get('eventBus').once('spiff.data_stores.requested', return_datastores);
+    // We Select a DataStoreReference element
+    const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
+    expect(shapeElement, "I can't find DataStoreReference element").to.exist;
 
-        // We Select a DataStoreReference element
-        const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
-        expect(shapeElement, "I can't find DataStoreReference element").to.exist;
+    // Interact with the DataStoreSelect component
+    const selectGroup = findGroupEntry(
+      'custom-datastore-properties',
+      container
+    );
+    expect(selectGroup).to.exist;
 
-        // Interact with the DataStoreSelect component
-        const selectGroup = findGroupEntry('custom-datastore-properties', container)
-        expect(selectGroup).to.exist;
+    const entry = findEntry('selectDataStore', getPropertiesPanel());
+    expect(entry).to.exist;
 
-        const entry = findEntry('selectDataStore', getPropertiesPanel());
-        expect(entry).to.exist;
+    // Verification if the dataStoreRef attribute is updated
+    const selector = findSelect(entry);
+    changeInput(selector, 'foodsID');
+    const nwbusinessObject = getBusinessObject(shapeElement);
+    expect(nwbusinessObject.get('dataStoreRef').id).to.equal('foodsID');
 
-        // Verification if the dataStoreRef attribute is updated
-        let selector = findSelect(entry);
-        changeInput(selector, 'foodsID');
-        const nwbusinessObject = getBusinessObject(shapeElement);
-        expect(nwbusinessObject.get('dataStoreRef').id).to.equal('foodsID');
+    // Check if the DataStore is added at the root level
+    const definitions = modeler.getDefinitions();
+    const dataStoreExists = definitions
+      .get('rootElements')
+      .some(
+        (element) =>
+          element.$type === 'bpmn:DataStore' && element.id === 'foodsID'
+      );
+    expect(
+      dataStoreExists,
+      "DataStore 'foodsID' should be added at the root level"
+    ).to.be.true;
+    modeler
+      .get('eventBus')
+      .off('spiff.data_stores.requested', return_datastores);
+  });
 
-        // Check if the DataStore is added at the root level
-        const definitions = modeler.getDefinitions();
-        const dataStoreExists = definitions.get('rootElements').some(element =>
-            element.$type === 'bpmn:DataStore' && element.id === 'foodsID'
-        );
-        expect(dataStoreExists, "DataStore 'foodsID' should be added at the root level").to.be.true;
-    });
+  it('should delete dataStore if dataStorRef is updated - DataStoreReference element', async function () {
+    const modeler = getBpmnJS();
+    modeler
+      .get('eventBus')
+      .once('spiff.data_stores.requested', return_datastores);
 
-    it('should delete dataStore if dataStorRef is updated - DataStoreReference element', async function () {
-        const modeler = getBpmnJS();
-        modeler.get('eventBus').once('spiff.data_stores.requested', return_datastores);
+    // We Select a DataStoreReference element
+    const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
+    expect(shapeElement, "I can't find DataStoreReference element").to.exist;
 
-        // We Select a DataStoreReference element
-        const shapeElement = await expectSelected('DataStoreReference_0eqeh4p');
-        expect(shapeElement, "I can't find DataStoreReference element").to.exist;
+    // Interact with the DataStoreSelect component
+    const selectGroup = findGroupEntry(
+      'custom-datastore-properties',
+      container
+    );
+    expect(selectGroup).to.exist;
 
-        // Interact with the DataStoreSelect component
-        const selectGroup = findGroupEntry('custom-datastore-properties', container)
-        expect(selectGroup).to.exist;
+    const entry = findEntry('selectDataStore', getPropertiesPanel());
+    expect(entry).to.exist;
 
-        const entry = findEntry('selectDataStore', getPropertiesPanel());
-        expect(entry).to.exist;
+    // Verification if the dataStoreRef attribute is updated
+    const selector = findSelect(entry);
+    changeInput(selector, 'foodsID');
+    let nwbusinessObject = getBusinessObject(shapeElement);
+    expect(nwbusinessObject.get('dataStoreRef').id).to.equal('foodsID');
+    // Then choose new dataStore
+    changeInput(selector, 'countriesID');
+    nwbusinessObject = getBusinessObject(shapeElement);
+    expect(nwbusinessObject.get('dataStoreRef').id).to.equal('countriesID');
 
-        // Verification if the dataStoreRef attribute is updated
-        let selector = findSelect(entry);
-        changeInput(selector, 'foodsID');
-        let nwbusinessObject = getBusinessObject(shapeElement);
-        expect(nwbusinessObject.get('dataStoreRef').id).to.equal('foodsID');
-        // Then choose new dataStore
-        changeInput(selector, 'countriesID');
-        nwbusinessObject = getBusinessObject(shapeElement);
-        expect(nwbusinessObject.get('dataStoreRef').id).to.equal('countriesID');
-
-        // Check if the DataStore is added at the root level with the updated dataStore
-        const definitions = modeler.getDefinitions();
-        const countriesDataStoreExists = definitions.get('rootElements').some(element =>
-            element.$type === 'bpmn:DataStore' && element.id === 'countriesID'
-        );
-        expect(countriesDataStoreExists, "DataStore 'countries' should be added at the root level").to.be.true;
-        const foodsDataStoreExists = definitions.get('rootElements').some(element =>
-            element.$type === 'bpmn:DataStore' && element.id === 'foodsID'
-        );
-        expect(foodsDataStoreExists, "DataStore 'countries' should be removed from the root level").not.to.be.true;
-
-    });
-
+    // Check if the DataStore is added at the root level with the updated dataStore
+    const definitions = modeler.getDefinitions();
+    const countriesDataStoreExists = definitions
+      .get('rootElements')
+      .some(
+        (element) =>
+          element.$type === 'bpmn:DataStore' && element.id === 'countriesID'
+      );
+    expect(
+      countriesDataStoreExists,
+      "DataStore 'countries' should be added at the root level"
+    ).to.be.true;
+    const foodsDataStoreExists = definitions
+      .get('rootElements')
+      .some(
+        (element) =>
+          element.$type === 'bpmn:DataStore' && element.id === 'foodsID'
+      );
+    expect(
+      foodsDataStoreExists,
+      "DataStore 'countries' should be removed from the root level"
+    ).not.to.be.true;
+    modeler
+      .get('eventBus')
+      .off('spiff.data_stores.requested', return_datastores);
+  });
 });


### PR DESCRIPTION
Avoid caching the spiff extension options from bpmn-js-spiffworkflow. This cache causes issues with react where it is unable to clear the variable when properly navigating between process models. The one calling can handle a cache of their own if it is desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Refactored `DataStoreReferenceSpec.js` for better readability and maintainability by reformatting imports, adjusting function declarations, enhancing code structure, and improving code comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->