### PR TITLE
allow empty service task params list

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
@@ -432,36 +432,40 @@ function createSignalButtonGroup(element, translate, moddle, commandStack) {
  * @returns entries
  */
 function createServiceGroup(element, translate, moddle, commandStack) {
+  let entries = [
+    {
+      element,
+      moddle,
+      commandStack,
+      component: ServiceTaskOperatorSelect,
+      translate,
+    },
+    {
+      element,
+      moddle,
+      commandStack,
+      component: ServiceTaskResultTextInput,
+      translate,
+    },
+  ];
+  if (typeof(element.businessObject.extensionElements) !== 'undefined' &&
+      typeof(element.businessObject.extensionElements.values[0].parameterList.parameters) !== 'undefined') {
+    entries.push({
+      id: 'serviceTaskParameters',
+      label: translate('Parameters'),
+      component: ListGroup,
+      shouldSort: false,
+      ...ServiceTaskParameterArray({
+        element,
+        moddle,
+        translate,
+        commandStack,
+      }),
+    });
+  }
   return {
     id: 'service_task_properties',
     label: translate('Spiffworkflow Service Properties'),
-    entries: [
-      {
-        element,
-        moddle,
-        commandStack,
-        component: ServiceTaskOperatorSelect,
-        translate,
-      },
-      {
-        element,
-        moddle,
-        commandStack,
-        component: ServiceTaskResultTextInput,
-        translate,
-      },
-      {
-        id: 'serviceTaskParameters',
-        label: translate('Parameters'),
-        component: ListGroup,
-        shouldSort: false,
-        ...ServiceTaskParameterArray({
-          element,
-          moddle,
-          translate,
-          commandStack,
-        }),
-      },
-    ],
+    entries: entries,
   };
 }

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
@@ -66,7 +66,7 @@ function getServiceTaskParameterModdleElements(shapeElement) {
     getServiceTaskOperatorModdleElement(shapeElement);
   if (serviceTaskOperatorModdleElement) {
     const { parameterList } = serviceTaskOperatorModdleElement;
-    if (parameterList) {
+    if (parameterList && typeof(parameterList.parameters) !== 'undefined') {
       return parameterList.parameters;
     }
   }


### PR DESCRIPTION
This checks to see if any parameters are defined before attempting to display the panel.  It also removes the parameter configuration completely when there is nothing to configure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced properties panel for service tasks with improved conditional display of parameters.
  
- **Bug Fixes**
	- Added checks to prevent errors related to undefined parameters in the service task properties.

These changes improve the user experience by ensuring that only relevant options are displayed, reducing confusion and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->