### PR TITLE
Deleting messages and changing message properties was not possible if correlation key reused between messages

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -3,7 +3,7 @@ import {
   BpmnPropertiesPanelModule,
   BpmnPropertiesProviderModule,
 } from 'bpmn-js-properties-panel';
-import diagramXML from '../test/spec/bpmn/mje.bpmn';
+import diagramXML from '../test/spec/bpmn/user_form.bpmn';
 import spiffworkflow from './spiffworkflow';
 import setupFileOperations from './fileOperations';
 import {
@@ -302,6 +302,16 @@ bpmnModeler.on('import.parse.complete', (event) => {
 });
 
 bpmnModeler.importXML(diagramXML).then(() => {});
+
+// Use this to simulate an add/update from the message editor.
+// bpmnModeler.on('spiff.message.edit', (event) => {
+//   event.eventBus.fire('spiff.add_message.returned', {
+//     elementId: "ActivityA",
+//     name: "messageA",
+//     correlation_properties:
+//       { "new_name": { retrieval_expression: "new_exp" }}
+//   });
+// });
 
 // This handles the download and upload buttons - it isn't specific to
 // the BPMN modeler or these extensions, just a quick way to allow you to

--- a/app/app.js
+++ b/app/app.js
@@ -3,7 +3,7 @@ import {
   BpmnPropertiesPanelModule,
   BpmnPropertiesProviderModule,
 } from 'bpmn-js-properties-panel';
-import diagramXML from '../test/spec/bpmn/user_form.bpmn';
+import diagramXML from '../test/spec/bpmn/mje.bpmn';
 import spiffworkflow from './spiffworkflow';
 import setupFileOperations from './fileOperations';
 import {

--- a/app/spiffworkflow/messages/MessageHelpers.js
+++ b/app/spiffworkflow/messages/MessageHelpers.js
@@ -832,11 +832,9 @@ export function synCorrleationProperties(
   for (let cProperty of correlationProps) {
     let isUsed = false;
     for (const cpExpression of cProperty.correlationPropertyRetrievalExpression) {
-      const msgRef = findMessageElement(
-        businessObject,
-        cpExpression.messageRef.id,
-        definitions,
-      );
+      const msgRef = cpExpression.messageRef
+        ? findMessageElement(businessObject, cpExpression.messageRef.id, definitions)
+        : undefined;
       isUsed =
         msgRef &&
         msgObject &&

--- a/app/spiffworkflow/messages/MessageInterceptor.js
+++ b/app/spiffworkflow/messages/MessageInterceptor.js
@@ -1,5 +1,5 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
-import { isMessageElement, isMessageRefUsed, setParentCorrelationKeys, synCorrleationProperties } from './MessageHelpers';
+import { isMessageElement, isMessageRefUsed, setParentCorrelationKeys, synCorrleationProperties, getRoot} from './MessageHelpers';
 
 const HIGH_PRIORITY = 90500;
 
@@ -16,8 +16,8 @@ export default class MessageInterceptor extends CommandInterceptor {
             if (isMessageElement(shape)) {
 
                 let oldMessageRef = (businessObject.eventDefinitions) ? businessObject.eventDefinitions[0].messageRef : businessObject.messageRef;
-                
-                let definitions = rootElement.businessObject.$parent;
+
+                let definitions = getRoot(rootElement, moddle)
                 if (!definitions.get('rootElements')) {
                     definitions.set('rootElements', []);
                 }

--- a/app/spiffworkflow/messages/MessageInterceptor.js
+++ b/app/spiffworkflow/messages/MessageInterceptor.js
@@ -1,5 +1,5 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
-import { isMessageElement, isMessageRefUsed, setParentCorrelationKeys, synCorrleationProperties, getRoot} from './MessageHelpers';
+import { isMessageElement, isMessageRefUsed, setParentCorrelationKeys, syncCorrelationProperties, getRoot} from './MessageHelpers';
 
 const HIGH_PRIORITY = 90500;
 
@@ -38,7 +38,7 @@ export default class MessageInterceptor extends CommandInterceptor {
                     }
 
                     // Automatic deletion of previous message correlation properties
-                    synCorrleationProperties(shape, definitions, moddle);
+                    syncCorrelationProperties(shape, definitions, moddle);
                 }
 
                 // Update Correlation key if Process has collaboration

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MatchingConditionArray.js
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MatchingConditionArray.js
@@ -26,7 +26,7 @@ export function MatchingCorrelationEntries(props) {
     const entries = (correlationPropertyArray && correlationPropertyArray.length !== 0) ? correlationPropertyArray.map(
         (correlationPropertyModdleElement, index) => {
             return {
-                id: `${idPrefix}-correlation-property-name`,
+                id: `${idPrefix}-correlation-property-`,
                 component: MatchingConditionTextField,
                 correlationPropertyModdleElement,
                 element,

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/TaskEventMessageProvider.js
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/TaskEventMessageProvider.js
@@ -142,12 +142,13 @@ export function createMessageGroup(
 
   // Adding Correlation Conditions Section
   const isMatchingCorrelation = businessObject.get('spiffworkflow:isMatchingCorrelation');
+  const id = businessObject.get('messageRef')?.id ?? "undefined";
   if (isMatchingCorrelation && isMatchingCorrelation !== "false" && canReceiveMessage(element)) {
     results.push({
       id: "correlationConditions",
       label: translate('Matching Conditions'),
       ...MatchingCorrelationEntries({
-        idPrefix: businessObject.get('messageRef').id,
+        idPrefix: id,
         element,
         moddle,
         commandStack,

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/TaskEventMessageProvider.js
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/TaskEventMessageProvider.js
@@ -147,6 +147,7 @@ export function createMessageGroup(
       id: "correlationConditions",
       label: translate('Matching Conditions'),
       ...MatchingCorrelationEntries({
+        idPrefix: businessObject.get('messageRef').id,
         element,
         moddle,
         commandStack,

--- a/test/spec/MessagesCorrSpec.js
+++ b/test/spec/MessagesCorrSpec.js
@@ -1,0 +1,92 @@
+import TestContainer from 'mocha-test-container-support';
+import {
+  query as domQuery,
+  queryAll as domQueryAll,
+} from 'min-dom';
+import {
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
+} from 'bpmn-js-properties-panel';
+import {
+  bootstrapPropertiesPanel,
+  expectSelected,
+  findEntry,
+  findGroupEntry,
+  findSelect,
+  findTextarea,
+  findInput,
+  pressButton,
+  findButtonByClass,
+  getPropertiesPanel,
+  changeInput,
+  findDivByClass
+} from './helpers';
+import spiffModdleExtension from '../../app/spiffworkflow/moddle/spiffworkflow.json';
+import messages from '../../app/spiffworkflow/messages';
+import { fireEvent } from '@testing-library/preact';
+import { getBpmnJS, inject } from 'bpmn-js/test/helper';
+import { findCorrelationProperties, findMessageModdleElements } from '../../app/spiffworkflow/messages/MessageHelpers';
+import {spiffExtensionOptions} from "../../app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect";
+
+describe('Multiple messages should work', function () {
+  const xml = require('./bpmn/two_messages.bpmn').default;
+  let container;
+
+  beforeEach(function () {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(
+    bootstrapPropertiesPanel(xml, {
+      container,
+      debounceInput: false,
+      additionalModules: [
+        messages,
+        BpmnPropertiesPanelModule,
+        BpmnPropertiesProviderModule,
+      ],
+      moddleExtensions: {
+        spiffworkflow: spiffModdleExtension,
+      },
+    })
+  );
+
+
+  const new_message_event = (eventBus) => {
+    eventBus.fire('spiff.add_message.returned', {
+      elementId: "ActivityA",
+      name: "messageA",
+      correlation_properties:
+        { "new_name": { retrieval_expression: "new_exp" }}
+    });
+  };
+
+
+  it('and it should be possible to change a correlation property name', async function () {
+    const modeler = getBpmnJS();
+
+    const sendShape = await expectSelected('ActivityA');
+    expect(sendShape, "Can't find Send Task").to.exist;
+
+    const oldName = "old_name"
+    const newName = "new_name"
+
+    const labels = domQueryAll(`.bio-properties-panel-label`, container);
+    const oldNameFound = Array.from(labels).some(label => label.textContent.includes(oldName));
+    expect(oldNameFound).to.be.true;
+
+    //Update message
+    new_message_event(modeler.get('eventBus'))
+    const sendShape2 = await expectSelected('ActivityA');
+
+    // The old name should no longer be there, but the new name should exist.
+    const labels2 = domQueryAll(`.bio-properties-panel-label`, container);
+    const oldNameFound2 = Array.from(labels2).some(label => label.textContent.includes(oldName));
+    expect(oldNameFound2).to.be.false;
+    const newNameFound2 = Array.from(labels2).some(label => label.textContent.includes(newName));
+    expect(newNameFound2).to.be.true;
+
+
+  });
+
+});

--- a/test/spec/MessagesSpec.js
+++ b/test/spec/MessagesSpec.js
@@ -22,9 +22,6 @@ import { fireEvent } from '@testing-library/preact';
 import { getBpmnJS, inject } from 'bpmn-js/test/helper';
 import { findCorrelationProperties, findMessageModdleElements } from '../../app/spiffworkflow/messages/MessageHelpers';
 
-import {
-  spiffExtensionOptions,
-} from '../../app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionSelect';
 
 describe('Messages should work', function () {
   const xml = require('./bpmn/collaboration.bpmn').default;

--- a/test/spec/MessagesSpec.js
+++ b/test/spec/MessagesSpec.js
@@ -98,7 +98,7 @@ describe('Messages should work', function () {
     const selector = findSelect(entry);
     expect(selector).to.exist;
     expect(selector.length).to.equal(2);
-    print(selector)
+    console.log(selector);
     await expectSelected('my_collaboration');
   });
 

--- a/test/spec/bpmn/two_messages.bpmn
+++ b/test/spec/bpmn/two_messages.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:message id="mje-process-receive-manual-entry-response" name="mje-process-receive-manual-entry-response" />
+  <bpmn:message id="mje-process-approval-bot-collect" name="mje-process-approval-bot-collect" />
+  <bpmn:process id="Process_0xyrvu1">
+    <bpmn:receiveTask id="ActivityA" name="A" messageRef="messageA" spiffworkflow:isMatchingCorrelation="true">
+      <bpmn:extensionElements>
+        <spiffworkflow:processVariableCorrelation>
+          <spiffworkflow:propertyId>old_name</spiffworkflow:propertyId>
+          <spiffworkflow:expression>"a"</spiffworkflow:expression>
+        </spiffworkflow:processVariableCorrelation>
+        <spiffworkflow:messageVariable>varA</spiffworkflow:messageVariable>
+      </bpmn:extensionElements>
+    </bpmn:receiveTask>
+    <bpmn:receiveTask id="ActivityB" name="B" messageRef="messageB" spiffworkflow:isMatchingCorrelation="true">
+      <bpmn:extensionElements>
+        <spiffworkflow:processVariableCorrelation>
+          <spiffworkflow:propertyId>old_name</spiffworkflow:propertyId>
+          <spiffworkflow:expression>"b"</spiffworkflow:expression>
+        </spiffworkflow:processVariableCorrelation>
+        <spiffworkflow:messageVariable>varB</spiffworkflow:messageVariable>
+      </bpmn:extensionElements>
+    </bpmn:receiveTask>
+  </bpmn:process>
+  <bpmn:message id="messageA" name="messageA" />
+  <bpmn:correlationProperty id="old_name" name="old_name">
+    <bpmn:correlationPropertyRetrievalExpression messageRef="messageA">
+      <bpmn:formalExpression>old_exp</bpmn:formalExpression>
+    </bpmn:correlationPropertyRetrievalExpression>
+    <bpmn:correlationPropertyRetrievalExpression messageRef="messageB">
+      <bpmn:formalExpression>old_exp</bpmn:formalExpression>
+    </bpmn:correlationPropertyRetrievalExpression>
+  </bpmn:correlationProperty>
+  <bpmn:correlationKey id="CorrelationKey_0k8fal6" name="MainCorrelationKey">
+    <bpmn:correlationPropertyRef>old_name</bpmn:correlationPropertyRef>
+  </bpmn:correlationKey>
+  <bpmn:message id="messageB" name="messageB" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0xyrvu1">
+      <bpmndi:BPMNShape id="Activity_00v6mgb_di" bpmnElement="ActivityA">
+        <dc:Bounds x="590" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xdpm2k_di" bpmnElement="ActivityB">
+        <dc:Bounds x="750" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
1. MatchingConditionArray, TaskEventMessageProvider.js - fixing the ids of div elements to make them easier to find in tests.
1. MessageHelpers - And added a deleteMessage function that will remove a message AND it's correlation properties. (The reason I came here)

1. MessageHelpers, MessageInterceptor.js - fixing the misspelled name of syncCorrelationProperties.

1. MessageCorrSpec tests that when you update a message through a message editor, it will correctly update the correlation properties, and not leave invalid properties lying around.

1. MessageSelect - will now remove the old message definition (including correlation properties), and replace it with the new message definition when a message is returned from the message editor.  As we do this when we receive a new message,there is no need for the cleanupOldMessage function when selecting a different message.

1. MessageSpec - a hell of a time with this.  "spiffExtensionOptions" is a constant that I could not seem to clear out between differest spec file tests.  I finally resorted to creating a "clearMessages" function that would force the list of messages to get cleared out when needed.

Co-authored-by: burnettk
Co-authored-by: jasquat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced message management in the BPMN properties panel with streamlined message deletion and support for handling multiple messages.
	- Added functionality to delete messages and manage correlation properties more effectively.
- **Bug Fixes**
	- Resolved naming inconsistencies to improve message correlation and overall reliability.
- **Tests**
	- Introduced new test cases to validate accurate message updates and deletion, ensuring enhanced consistency in message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->