### PR TITLE
check-all-ext-props

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
@@ -23,6 +23,7 @@ import { SpiffExtensionTextInput } from './SpiffExtensionTextInput';
 import { SpiffExtensionCheckboxEntry } from './SpiffExtensionCheckboxEntry';
 import { hasEventDefinition } from 'bpmn-js/lib/util/DiUtil';
 import { setExtensionValue } from '../extensionHelpers';
+import { checkIfServiceTaskHasParameters } from '../../helpers'
 
 const LOW_PRIORITY = 500;
 
@@ -34,7 +35,7 @@ export default function ExtensionsPropertiesProvider(
   elementRegistry,
 ) {
   this.getGroups = function (element) {
-    return function(groups) {
+    return function (groups) {
       if (is(element, 'bpmn:ScriptTask')) {
         groups.push(
           createScriptGroup(element, translate, moddle, commandStack),
@@ -88,7 +89,7 @@ export default function ExtensionsPropertiesProvider(
           createSignalButtonGroup(element, translate, moddle, commandStack),
         );
       }
-      
+
       if (is(element, 'bpmn:ServiceTask')) {
         groups.push(
           createServiceGroup(element, translate, moddle, commandStack),
@@ -451,8 +452,8 @@ function createServiceGroup(element, translate, moddle, commandStack) {
       translate,
     },
   ];
-  if (typeof(element.businessObject.extensionElements) !== 'undefined' &&
-      typeof(element.businessObject.extensionElements.values[0].parameterList.parameters) !== 'undefined') {
+  if (typeof (element.businessObject.extensionElements) !== 'undefined' &&
+    checkIfServiceTaskHasParameters(element.businessObject.extensionElements)) {
     entries.push({
       id: 'serviceTaskParameters',
       label: translate('Parameters'),

--- a/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
+++ b/app/spiffworkflow/extensions/propertiesPanel/SpiffExtensionServiceProperties.js
@@ -66,7 +66,7 @@ function getServiceTaskParameterModdleElements(shapeElement) {
     getServiceTaskOperatorModdleElement(shapeElement);
   if (serviceTaskOperatorModdleElement) {
     const { parameterList } = serviceTaskOperatorModdleElement;
-    if (parameterList && typeof(parameterList.parameters) !== 'undefined') {
+    if (parameterList && "parameters" in parameterList && typeof (parameterList.parameters) !== 'undefined') {
       return parameterList.parameters;
     }
   }

--- a/app/spiffworkflow/helpers.js
+++ b/app/spiffworkflow/helpers.js
@@ -46,3 +46,13 @@ export function processId(id) {
   }
   return processedId;
 }
+
+export function checkIfServiceTaskHasParameters(extensionElements) {
+  let hasParameters = false;
+  extensionElements.values.forEach((item) => {
+    if ("parameterList" in item && "parameters" in item.parameterList && typeof (item.parameterList.parameters) !== "undefined") {
+      hasParameters = true
+    }
+  })
+  return hasParameters;
+}


### PR DESCRIPTION
This checks all of the extension properties of a service task for parameters instead of just the first element. It also ensures that `parameters` is actually a key on the element as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized check for service task parameters to streamline processing.

- **Refactor**
  - Enhanced conditional logic to verify parameter presence, improving robustness and maintainability.
  - Standardized formatting for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->