### PR TITLE
add ability to specify where user form data is stored

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
@@ -270,6 +270,15 @@ function createUserGroup(element, translate, moddle, commandStack) {
         listenFunction: updateExtensionProperties,
         description: translate('Edit the form schema'),
       },
+      {
+        element,
+        moddle,
+        commandStack,
+        component: SpiffExtensionTextInput,
+        name: 'spiffworkflow:VariableName',
+        label: 'Variable Name',
+        description: 'Store form results in this variable',
+      },
     ],
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Variable Name” field to the User Task properties panel, enabling users to specify where form results are stored.
  * Includes a helpful description to guide configuration directly within the properties group.
  * Integrates with existing properties without altering other behaviors, providing a seamless editing experience.
  * Changes are reflected in the workflow model, improving clarity and control over how form data is persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->