### PR TITLE
Fix DataOutput arrow fill color

### DIFF
--- a/app/spiffworkflow/DataObject/DataObjectRenderer.js
+++ b/app/spiffworkflow/DataObject/DataObjectRenderer.js
@@ -1,6 +1,6 @@
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
 
-import { attr as svgAttr } from 'tiny-svg';
+import { attr as svgAttr, select as svgSelect } from 'tiny-svg';
 
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
@@ -19,7 +19,7 @@ export default class DataObjectRenderer extends BaseRenderer {
   }
 
   canRender(element) {
-    return isAny(element, ['bpmn:DataObjectReference']) && !element.labelTarget;
+    return isAny(element, ['bpmn:DataObjectReference', 'bpmn:DataOutput']) && !element.labelTarget;
   }
 
   drawShape(parentNode, element) {
@@ -33,6 +33,16 @@ export default class DataObjectRenderer extends BaseRenderer {
       }
       if (!dataObject) {
         svgAttr(shape, 'stroke', 'red');
+      }
+      return shape;
+    }
+    if (is(element, 'bpmn:DataOutput')) {
+      // Fix: bpmn-js renders the DataOutput arrow with background fill,
+      // but it should be filled with the stroke color (solid arrow).
+      const arrowPath = svgSelect(parentNode, 'path:nth-of-type(2)');
+      if (arrowPath) {
+        const strokeColor = svgAttr(arrowPath, 'stroke') || '#000';
+        svgAttr(arrowPath, 'fill', strokeColor);
       }
       return shape;
     }


### PR DESCRIPTION
## Summary
- Fixed the DataOutput arrow rendering to use the stroke color instead of the background fill, so the arrow appears solid as expected.

## Test plan
- [ ] Verify DataOutput elements render with a solid arrow in the diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering additional diagram element types.

* **Bug Fixes**
  * Fixed visual rendering and styling of diagram elements to display correctly.

Addresses: https://github.com/sartography/bpmn-js-spiffworkflow/issues/118

<!-- end of auto-generated comment: release notes by coderabbit.ai -->