### PR TITLE
Maje sure that a data object exists, before attempting to delete it.

### DIFF
--- a/app/spiffworkflow/DataObject/DataObjectInterceptor.js
+++ b/app/spiffworkflow/DataObject/DataObjectInterceptor.js
@@ -130,6 +130,7 @@ export default class DataObjectInterceptor extends CommandInterceptor {
       const { shape } = context;
       if (is(shape, 'bpmn:DataObjectReference') && shape.type !== 'label') {
         const dataObject = shape.businessObject.dataObjectRef;
+
         let parent = shape.businessObject.$parent;
         if (parent.processRef) {
           // Our immediate parent may be a pool, so we need to get the process
@@ -137,13 +138,15 @@ export default class DataObjectInterceptor extends CommandInterceptor {
         }
         const flowElements = parent.get('flowElements');
         collectionRemove(flowElements, shape.businessObject);
-        const references = findDataObjectReferences(
-          flowElements,
-          dataObject.id
-        );
-        if (references.length === 0) {
-          const dataFlowElements = dataObject.$parent.get('flowElements');
-          collectionRemove(dataFlowElements, dataObject);
+        if (dataObject) {
+          const references = findDataObjectReferences(
+            flowElements,
+            dataObject.id
+          );
+          if (references.length === 0) {
+            const dataFlowElements = dataObject.$parent.get('flowElements');
+            collectionRemove(dataFlowElements, dataObject);
+          }
         }
       }
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential crash when deleting data object references in workflow diagrams by adding proper null validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->