### PR TITLE
Allow setting a messages json schema to a local file reference.

### DIFF
--- a/app/spiffworkflow/messages/MessageHelpers.js
+++ b/app/spiffworkflow/messages/MessageHelpers.js
@@ -828,54 +828,59 @@ export function syncCorrelationProperties(
 ) {
   const { businessObject } = element;
   const correlationProps = findCorrelationProperties(businessObject, moddle);
-  const messageId = msgObject?.identifier;
   const activePropertyIds = new Set(
     (msgObject?.correlation_properties || []).map((obj) => obj.identifier)
   );
 
-  for (const cProperty of correlationProps) {
-    const nextExpressions = (
-      cProperty.correlationPropertyRetrievalExpression || []
-    ).filter((cpExpression) => {
-      if (!cpExpression.messageRef?.id) {
-        return false;
-      }
-
-      const msgRef = findMessageElement(
-        businessObject,
-        cpExpression.messageRef.id,
-        definitions
-      );
-
+  for (let cProperty of correlationProps) {
+    let isUsed = false;
+    const expressionsToDelete = [];
+    for (const cpExpression of cProperty.correlationPropertyRetrievalExpression) {
+      const msgRef = cpExpression.messageRef
+        ? findMessageElement(
+            businessObject,
+            cpExpression.messageRef.id,
+            definitions
+          )
+        : undefined;
+      isUsed =
+        msgRef &&
+        msgObject &&
+        cpExpression.messageRef.id !== msgObject.identifier
+          ? true
+          : isUsed;
+      // if unused  false, delete retrival expression
       if (!msgRef) {
-        return false;
+        expressionsToDelete.push(cpExpression);
       }
-
-      if (messageId && cpExpression.messageRef.id === messageId) {
-        return activePropertyIds.has(cProperty.id);
-      }
-
-      return true;
-    });
-
-    cProperty.correlationPropertyRetrievalExpression = nextExpressions;
-
-    const hasOtherMessageReferences = nextExpressions.some(
-      (cpExpression) => cpExpression.messageRef?.id !== messageId
-    );
-    const keepProperty =
-      activePropertyIds.has(cProperty.id) || hasOtherMessageReferences;
-    const cPropertyIndex = definitions.get('rootElements').indexOf(cProperty);
-
-    if (!keepProperty) {
-      if (cPropertyIndex > -1) {
-        definitions.rootElements.splice(cPropertyIndex, 1);
-      }
-      continue;
     }
 
-    if (cPropertyIndex > -1) {
-      definitions.rootElements.splice(cPropertyIndex, 1, cProperty);
+    // Delete the retrieval expressions that are not used
+    for (const expression of expressionsToDelete) {
+      const index =
+        cProperty.correlationPropertyRetrievalExpression.indexOf(expression);
+      if (index > -1) {
+        cProperty.correlationPropertyRetrievalExpression.splice(index, 1);
+        const cPropertyIndex = definitions
+          .get('rootElements')
+          .indexOf(cProperty);
+        definitions.rootElements.splice(cPropertyIndex, 1, cProperty);
+      }
+    }
+
+    // If Unused, delete the correlation property
+    const propertyToBeDeleted =
+      isUsed ||
+      (msgObject &&
+        msgObject.correlation_properties &&
+        msgObject.correlation_properties.some(
+          (obj) => obj.identifier === cProperty.id
+        ));
+    if (!propertyToBeDeleted) {
+      const index = definitions.get('rootElements').indexOf(cProperty);
+      if (index > -1) {
+        definitions.rootElements.splice(index, 1);
+      }
     }
   }
 
@@ -898,6 +903,41 @@ function removeUnusedProcessVariableCorrelations(element, activePropertyIds) {
       activePropertyIds.has(value.propertyId)
     );
   });
+}
+
+export function getMessageSchemaFile(messageBo) {
+  if (!messageBo?.extensionElements) return '';
+  const props = messageBo.extensionElements
+    .get('values')
+    .find((e) => e.$instanceOf('spiffworkflow:Properties'));
+  if (!props) return '';
+  const prop = props
+    .get('properties')
+    .find((p) => p.name === 'formJsonSchemaFilename');
+  return prop?.value ?? '';
+}
+
+export function setMessageSchemaFile(messageBo, schemaFile, moddle) {
+  if (!messageBo.extensionElements) {
+    messageBo.extensionElements = moddle.create('bpmn:ExtensionElements');
+  }
+  const exts = messageBo.extensionElements;
+  let props = exts
+    .get('values')
+    .find((e) => e.$instanceOf('spiffworkflow:Properties'));
+  if (!props) {
+    props = moddle.create('spiffworkflow:Properties');
+    exts.get('values').push(props);
+  }
+  let prop = props
+    .get('properties')
+    .find((p) => p.name === 'formJsonSchemaFilename');
+  if (!prop) {
+    prop = moddle.create('spiffworkflow:Property');
+    props.get('properties').push(prop);
+  }
+  prop.name = 'formJsonSchemaFilename';
+  prop.value = schemaFile;
 }
 
 export function deleteMessage(definitions, messageId) {

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageJsonSchemaSelect.js
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageJsonSchemaSelect.js
@@ -1,6 +1,11 @@
 import { useService } from 'bpmn-js-properties-panel';
 import { SelectEntry } from '@bpmn-io/properties-panel';
-import { getMessageRefElement, getRoot } from '../../MessageHelpers';
+import {
+  getMessageRefElement,
+  getRoot,
+  getMessageSchemaFile,
+  setMessageSchemaFile,
+} from '../../MessageHelpers';
 
 export const spiffExtensionOptions = {};
 
@@ -13,6 +18,7 @@ export function MessageJsonSchemaSelect(props) {
   const debounce = useService('debounceInput');
   const eventBus = useService('eventBus');
   const bpmnFactory = useService('bpmnFactory');
+  const moddle = useService('moddle');
 
   const optionType = 'messages_schemas';
 
@@ -29,20 +35,19 @@ export function MessageJsonSchemaSelect(props) {
       definitions.set('rootElements', []);
     }
 
-    // Retrieve Message
     let bpmnMessage = definitions
       .get('rootElements')
       .find(
-        (element) =>
-          element.$type === 'bpmn:Message' &&
-          (element.id === msgRef.id || element.name === msgRef.id)
+        (el) =>
+          el.$type === 'bpmn:Message' &&
+          (el.id === msgRef.id || el.name === msgRef.id)
       );
 
     if (!bpmnMessage) {
       return '';
     }
 
-    return bpmnMessage.get('jsonSchemaId');
+    return getMessageSchemaFile(bpmnMessage);
   };
 
   const setValue = (value) => {
@@ -63,32 +68,14 @@ export function MessageJsonSchemaSelect(props) {
     let bpmnMessage = definitions
       .get('rootElements')
       .find(
-        (element) =>
-          element.$type === 'bpmn:Message' &&
-          (element.id === msgRef.id || element.name === msgRef.id)
+        (el) =>
+          el.$type === 'bpmn:Message' &&
+          (el.id === msgRef.id || el.name === msgRef.id)
       );
-    bpmnMessage.set('jsonSchemaId', value);
 
-    // let extensions = businessObject.extensionElements;
-    // if (!extensions) {
-    //     extensions = moddle.create('bpmn:ExtensionElements');
-    //     extensions.values = []
-    // }
-    // const properties = moddle.create(
-    //     MESSAGE_JSONSCHEMA_PARAMETER_ELEMENT_NAME
-    // );
-    // properties.values = []
-    // const property = moddle.create(
-    //     'spiffworkflow:Property'
-    // );
-    // property.name = "jsonSchemaId";
-    // property.value = value;
-    // properties.values.push(property)
-    // extensions.values.push(properties)
-    // let definitions = getRoot(businessObject);
-    // if (!definitions.get('rootElements')) {
-    //     definitions.set('rootElements', []);
-    // }
+    if (bpmnMessage) {
+      setMessageSchemaFile(bpmnMessage, value, moddle);
+    }
   };
 
   if (

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageLaunchEditorButton.js
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageLaunchEditorButton.js
@@ -38,8 +38,6 @@ export function MessageLaunchEditorButton(props) {
     className: 'spiffworkflow-properties-panel-button',
     id: `message_launch_message_editor_button`,
     onClick: () => {
-      // eventBus.fire('spiff.add_message.requested', { eventBus });
-
       eventBus.fire(sendEvent, {
         value: {
           elementId: element.id,

--- a/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageSelect.jsx
+++ b/app/spiffworkflow/messages/propertiesPanel/elementLevelProvider/MessageSelect.jsx
@@ -12,6 +12,7 @@ import {
   setParentCorrelationKeys,
   syncCorrelationProperties,
   deleteMessage,
+  setMessageSchemaFile,
 } from '../../MessageHelpers';
 import { SPIFF_ADD_MESSAGE_RETURNED_EVENT } from '../../../constants';
 
@@ -133,7 +134,15 @@ export function MessageSelect(props) {
     } else {
       spiffExtensionOptions['spiff.messages'].push(newMsg);
     }
-    setValue(event.name);
+    await setValue(event.name);
+
+    if (event.schema_file) {
+      const defs = getRoot(element.businessObject);
+      const bpmnMessage = findMessageById(defs, event.name);
+      if (bpmnMessage) {
+        setMessageSchemaFile(bpmnMessage, event.schema_file, moddle);
+      }
+    }
   });
 
   requestOptions(eventBus, bpmnFactory, element, moddle);

--- a/test/spec/MessagesSpec.js
+++ b/test/spec/MessagesSpec.js
@@ -20,7 +20,7 @@ import spiffModdleExtension from '../../app/spiffworkflow/moddle/spiffworkflow.j
 import messages from '../../app/spiffworkflow/messages';
 import { fireEvent } from '@testing-library/preact';
 import { getBpmnJS, inject } from 'bpmn-js/test/helper';
-import { findCorrelationProperties, findMessageModdleElements } from '../../app/spiffworkflow/messages/MessageHelpers';
+import { findCorrelationProperties, findMessageModdleElements, getMessageSchemaFile, setMessageSchemaFile } from '../../app/spiffworkflow/messages/MessageHelpers';
 import { SPIFF_ADD_MESSAGE_RETURNED_EVENT } from '../../app/spiffworkflow/constants';
 
 
@@ -96,7 +96,6 @@ describe('Messages should work', function () {
     const selector = findSelect(entry);
     expect(selector).to.exist;
     expect(selector.length).to.equal(2);
-    console.log(selector);
     await expectSelected('my_collaboration');
   });
 
@@ -243,7 +242,105 @@ describe('Messages should work', function () {
     expect(updatedXml).not.to.include('<bpmn:correlationProperty id="singer_name"');
   }));
 
+  it('should store a schema file on a message via the add_message event', inject(async function (canvas, moddle) {
+    const modeler = getBpmnJS();
+    const eventBus = modeler.get('eventBus');
+    const rootShape = canvas.getRootElement();
 
+    const sendShape = await expectSelected('ActivitySendLetter');
+    expect(sendShape, "Can't find Send Task").to.exist;
+
+    eventBus.fire(SPIFF_ADD_MESSAGE_RETURNED_EVENT, {
+      elementId: sendShape.id,
+      name: 'love_letter',
+      correlation_properties: {
+        lover_instrument: { retrieval_expression: 'lover.instrument' },
+        lover_name: { retrieval_expression: 'lover.name' },
+      },
+      schema_file: 'my_schema.json',
+    });
+
+    // Allow the async event handler to complete (schema_file is set after await)
+    await new Promise((r) => setTimeout(r, 0));
+
+    const definitions = modeler.getDefinitions();
+    const bpmnMessage = definitions.rootElements.find(
+      (el) => el.$type === 'bpmn:Message' && (el.id === 'love_letter' || el.name === 'love_letter')
+    );
+    expect(bpmnMessage, 'Message should exist in definitions').to.exist;
+
+    const schemaFile = getMessageSchemaFile(bpmnMessage);
+    expect(schemaFile).to.equal('my_schema.json');
+
+    const { xml: updatedXml } = await modeler.saveXML({ format: true });
+    expect(updatedXml).to.include('formJsonSchemaFilename');
+    expect(updatedXml).to.include('my_schema.json');
+  }));
+
+  it('should update an existing schema file on a message', inject(async function (canvas, moddle) {
+    const modeler = getBpmnJS();
+    const eventBus = modeler.get('eventBus');
+
+    const sendShape = await expectSelected('ActivitySendLetter');
+    expect(sendShape, "Can't find Send Task").to.exist;
+
+    // Set an initial schema file on the love_letter message
+    const definitions = modeler.getDefinitions();
+    const bpmnMessage = definitions.rootElements.find(
+      (el) => el.$type === 'bpmn:Message' && el.id === 'love_letter'
+    );
+    setMessageSchemaFile(bpmnMessage, 'old_schema.json', moddle);
+    expect(getMessageSchemaFile(bpmnMessage)).to.equal('old_schema.json');
+
+    // Fire event with updated schema_file
+    eventBus.fire(SPIFF_ADD_MESSAGE_RETURNED_EVENT, {
+      elementId: sendShape.id,
+      name: 'love_letter',
+      correlation_properties: {
+        lover_instrument: { retrieval_expression: 'lover.instrument' },
+        lover_name: { retrieval_expression: 'lover.name' },
+      },
+      schema_file: 'new_schema.json',
+    });
+
+    // Allow the async event handler to complete (schema_file is set after await)
+    await new Promise((r) => setTimeout(r, 0));
+
+    const updatedMessage = definitions.rootElements.find(
+      (el) => el.$type === 'bpmn:Message' && (el.id === 'love_letter' || el.name === 'love_letter')
+    );
+    expect(getMessageSchemaFile(updatedMessage)).to.equal('new_schema.json');
+  }));
+
+  it('should not add schema extensions when no schema_file is provided', inject(async function (canvas) {
+    const modeler = getBpmnJS();
+    const eventBus = modeler.get('eventBus');
+
+    const sendShape = await expectSelected('ActivitySendLetter');
+    expect(sendShape, "Can't find Send Task").to.exist;
+
+    // Fire event without schema_file (simulating older systems)
+    eventBus.fire(SPIFF_ADD_MESSAGE_RETURNED_EVENT, {
+      elementId: sendShape.id,
+      name: 'love_letter',
+      correlation_properties: {
+        lover_instrument: { retrieval_expression: 'lover.instrument' },
+        lover_name: { retrieval_expression: 'lover.name' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const definitions = modeler.getDefinitions();
+    const bpmnMessage = definitions.rootElements.find(
+      (el) => el.$type === 'bpmn:Message' && (el.id === 'love_letter' || el.name === 'love_letter')
+    );
+    expect(bpmnMessage, 'Message should exist').to.exist;
+    expect(getMessageSchemaFile(bpmnMessage)).to.equal('');
+
+    const { xml: updatedXml } = await modeler.saveXML({ format: true });
+    expect(updatedXml).to.not.include('formJsonSchemaFilename');
+  }));
 
   // 🔶🔶 OLD Features
 


### PR DESCRIPTION
This allows us to connect a json schema file to a bpmn:Message.  This will allow the BPMN file to contain everything about how a message works, and provides a way to collaborate on a message definition between Ed and Arena such that everything is included in the BPMN file and no additional configuration files are required - working much the same way user tasks currently reference locally json files.

We will still have to deal with the problem of the schema up-search in Arena. 


So it is possible to update  and retrieve a link to a json schema that is connected directy to a bpmn:message element, as shown below.
 ```xml
  <bpmn:message id="remote_update" name="remote_update">
      <bpmn:extensionElements>
          <spiffworkflow:property name="formJsonSchemaFilename" value="mission-parameters-schema.json" />
        </spiffworkflow:properties>
  </bpmn:message>
```