### PR TITLE
user task available hook w/ jasquat

### DIFF
--- a/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
+++ b/app/spiffworkflow/extensions/propertiesPanel/ExtensionsPropertiesProvider.jsx
@@ -81,6 +81,9 @@ export default function ExtensionsPropertiesProvider(
           createAllowGuestGroup(element, translate, moddle, commandStack)
         );
       }
+      if (isAny(element, ['bpmn:ManualTask', 'bpmn:UserTask'])) {
+        groups.push(createHooksGroup(element, translate, moddle, commandStack));
+      }
       if (
         is(element, 'bpmn:BoundaryEvent') &&
         hasEventDefinition(element, 'bpmn:SignalEventDefinition') &&
@@ -325,6 +328,32 @@ function createBusinessRuleGroup(element, translate, moddle, commandStack) {
         label: translate('Launch Editor'),
         event: 'spiff.dmn.edit',
         description: translate('Modify the Decision Table'),
+      },
+    ],
+  };
+}
+
+/**
+ * Create a group for task lifecycle hooks.
+ * @param element
+ * @param translate
+ * @param moddle
+ * @param commandStack
+ * @returns entries
+ */
+function createHooksGroup(element, translate, moddle, commandStack) {
+  return {
+    id: 'hooks',
+    label: translate('Task Hooks'),
+    entries: [
+      {
+        element,
+        moddle,
+        commandStack,
+        component: SpiffExtensionTextInput,
+        name: 'spiffworkflow:ProcessModelToStartOnTaskAvailable',
+        label: 'Process Model to Start on Task Available',
+        description: 'Start this process model when the task becomes available',
       },
     ],
   };

--- a/app/spiffworkflow/moddle/spiffworkflow.json
+++ b/app/spiffworkflow/moddle/spiffworkflow.json
@@ -138,6 +138,17 @@
       ]
     },
     {
+      "name": "ProcessModelToStartOnTaskAvailable",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "value",
+          "isBody": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "Properties",
       "superClass": ["Element"],
       "properties": [

--- a/test/spec/UserTaskPropsSpec.js
+++ b/test/spec/UserTaskPropsSpec.js
@@ -109,6 +109,52 @@ describe('Properties Panel for User Tasks', function () {
     expect(formJsonSchemaFilenameInput.value).to.equal('give_me_a_number_form.json');
   });
 
+  it('should serialize the process model to start on task available extension', async function () {
+    await preparePropertiesPanelWithXml(user_form_xml)();
+
+    const userTask = await expectSelected('my_user_task');
+    const group = findGroupEntry('hooks', container);
+    const entry = findEntry(
+      'extension_spiffworkflow:ProcessModelToStartOnTaskAvailable',
+      group
+    );
+    const input = findInput('text', entry);
+    expect(input).to.exist;
+
+    changeInput(input, 'task-hooks/task-available');
+
+    const processModelToStartOnTaskAvailable = getExtensionValue(
+      userTask.businessObject,
+      'spiffworkflow:ProcessModelToStartOnTaskAvailable'
+    );
+    expect(processModelToStartOnTaskAvailable).to.equal(
+      'task-hooks/task-available'
+    );
+  });
+
+  it('should display the process model to start on task available extension for manual tasks', async function () {
+    await preparePropertiesPanelWithXml(diagram_xml)();
+
+    const manualTask = await expectSelected('Activity_15zz6ya');
+    const group = findGroupEntry('hooks', container);
+    const entry = findEntry(
+      'extension_spiffworkflow:ProcessModelToStartOnTaskAvailable',
+      group
+    );
+    const input = findInput('text', entry);
+    expect(input).to.exist;
+
+    changeInput(input, 'task-hooks/manual-task-available');
+
+    const processModelToStartOnTaskAvailable = getExtensionValue(
+      manualTask.businessObject,
+      'spiffworkflow:ProcessModelToStartOnTaskAvailable'
+    );
+    expect(processModelToStartOnTaskAvailable).to.equal(
+      'task-hooks/manual-task-available'
+    );
+  });
+
   it('should update both the json and ui extensions if the json file is set', async function () {
     await preparePropertiesPanelWithXml(diagram_xml)();
     const modeler = getBpmnJS();


### PR DESCRIPTION
Adds support to add a process model to a task that will run when that task is marked ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Task Hooks" configuration for manual tasks and user tasks, allowing users to specify which process model should start when a task becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->