### PR TITLE
add group for ad hoc subprocess completion

### DIFF
--- a/app/spiffworkflow/adHocSubProcess/propertiesPanel/AdHocSubProcessPropertiesProvider.js
+++ b/app/spiffworkflow/adHocSubProcess/propertiesPanel/AdHocSubProcessPropertiesProvider.js
@@ -31,7 +31,6 @@ export default function AdHocSubProcessPropertiesProvider(propertiesPanel) {
 AdHocSubProcessPropertiesProvider.$inject = ['propertiesPanel'];
 
 function AdHocSubProcessProps(props) {
-  const { element } = props;
   return [
     {
       id: 'completionCondition',

--- a/app/spiffworkflow/adHocSubProcess/propertiesPanel/AdHocSubProcessPropertiesProvider.js
+++ b/app/spiffworkflow/adHocSubProcess/propertiesPanel/AdHocSubProcessPropertiesProvider.js
@@ -1,0 +1,123 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { useService } from 'bpmn-js-properties-panel';
+import {
+  Group,
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  CheckboxEntry,
+  isCheckboxEntryEdited,
+} from '@bpmn-io/properties-panel';
+
+const LOW_PRIORITY = 500;
+
+export default function AdHocSubProcessPropertiesProvider(propertiesPanel) {
+  this.getGroups = function getGroups(element) {
+    return function addGroup(groups)  {
+      if (is(element, 'bpmn:AdHocSubProcess')) {
+        groups.push({
+          id: 'adHocSubProcessProperties',
+          component: Group,
+          label: 'SubProcess Completion',
+          entries: AdHocSubProcessProps(element),
+          shouldOpen: true,
+        });
+      }
+      return groups;
+    };
+  };
+  propertiesPanel.registerProvider(LOW_PRIORITY, this);
+};
+
+AdHocSubProcessPropertiesProvider.$inject = ['propertiesPanel'];
+
+function AdHocSubProcessProps(props) {
+  const { element } = props;
+  return [
+    {
+      id: 'completionCondition',
+      component: CompletionCondition,
+      isEdited: isTextFieldEntryEdited,
+    },
+    {
+      id: 'cancelRemaining',
+      component: CancelRemaining,
+      isEdited: isCheckboxEntryEdited,
+    },
+  ];
+}
+
+function CompletionCondition(props) {
+
+  const { element } = props;
+  const debounce = useService('debounceInput');
+  const translate = useService('translate');
+  const commandStack = useService('commandStack');
+  const bpmnFactory = useService('bpmnFactory');
+
+  const getValue = () => {
+    const value = element.businessObject.get('completionCondition');
+    return (typeof value !== 'undefined') ? value.body : '';
+  };
+
+  const setValue = (value) => {
+    if (!value || value === '') {
+      commandStack.execute('element.updateModdleProperties', {
+        element,
+        moddleElement: element.businessObject,
+        properties: {
+          completionCondition: null,
+        },
+      });
+    } else {
+      const condition = bpmnFactory.create('bpmn:Expression', {
+        body: value,
+      });
+      commandStack.execute('element.updateModdleProperties', {
+        element,
+        moddleElement: element.businessObject,
+        properties: {
+          completionCondition: condition,
+        },
+      });
+    }
+  };
+
+  return TextFieldEntry({
+    element,
+    id: 'completionCondition',
+    label: translate('Completion Condition'),
+    getValue,
+    setValue,
+    debounce,
+    description: 'Stop executing when this condition is met.',
+  });
+}
+
+function CancelRemaining(props) {
+
+  const { element } = props;
+  const translate = useService('translate');
+  const commandStack = useService('commandStack');
+
+  const getValue = () => {
+    return element.businessObject.cancelRemainingInstances;
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: element.businessObject,
+      properties: {
+        cancelRemainingInstances: value,
+      },
+    });
+  };
+
+  return CheckboxEntry({
+    element,
+    id: 'cancelRemaining',
+    label: translate('Cancel active tasks when complete'),
+    getValue,
+    setValue,
+  });
+}

--- a/app/spiffworkflow/index.js
+++ b/app/spiffworkflow/index.js
@@ -23,6 +23,7 @@ import MultiInstancePropertiesProvider from './loops/MultiInstancePropertiesProv
 import CallActivityInterceptor from './callActivity/CallActivityInterceptor';
 import MessageInterceptor from './messages/MessageInterceptor';
 import CustomContextPadProvider from './extensions/contextPad/CustomContextPadProvider';
+import AdHocSubProcessPropertiesProvider from './adHocSubProcess/propertiesPanel/AdHocSubProcessPropertiesProvider';
 
 export default {
   __depends__: [RulesModule],
@@ -51,6 +52,7 @@ export default {
     'IoPropertiesProvider',
     'DataInputOutputPropertiesProvider',
     'callActivityInterceptor',
+    'adHocSubProcessPropertiesProvider',
   ],
   dataObjectInterceptor: ['type', DataObjectInterceptor],
   dataObjectRules: ['type', DataObjectRules],
@@ -76,4 +78,5 @@ export default {
   IoPropertiesProvider: ['type', IoPropertiesProvider],
   DataInputOutputPropertiesProvider: ['type', DataInputOutputPropertiesProvider],
   callActivityInterceptor: ['type', CallActivityInterceptor],
+  adHocSubProcessPropertiesProvider: ['type', AdHocSubProcessPropertiesProvider],
 };


### PR DESCRIPTION
This adds a group for ad hoc subprocess properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Properties Panel section for ad-hoc subprocess elements.
  * Users can now configure **SubProcess Completion** with an editable completion condition and a toggle to cancel any remaining active instances.
* **Integration**
  * Wired the new provider into the workflow module so these settings appear in the Properties Panel for applicable elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->